### PR TITLE
Initial commit for Directed broadcast support

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -14,6 +14,7 @@ extern sai_object_id_t gVirtualRouterId;
 
 extern sai_router_interface_api_t*  sai_router_intfs_api;
 extern sai_route_api_t*             sai_route_api;
+extern sai_neighbor_api_t*          sai_neighbor_api;
 
 extern PortsOrch *gPortsOrch;
 extern sai_object_id_t gSwitchId;
@@ -145,6 +146,10 @@ void IntfsOrch::doTask(Consumer &consumer)
 
             addSubnetRoute(port, ip_prefix);
             addIp2MeRoute(ip_prefix);
+            if(port.m_type == Port::VLAN && ip_prefix.isV4())
+            {
+                addDirectedBroadcast(port, ip_prefix.getBroadcastIp());
+            }
 
             m_syncdIntfses[alias].ip_addresses.insert(ip_prefix);
             it = consumer.m_toSync.erase(it);
@@ -172,6 +177,10 @@ void IntfsOrch::doTask(Consumer &consumer)
                 {
                     removeSubnetRoute(port, ip_prefix);
                     removeIp2MeRoute(ip_prefix);
+                    if(port.m_type == Port::VLAN && ip_prefix.isV4())
+                    {
+                        removeDirectedBroadcast(port, ip_prefix.getBroadcastIp());
+                    }
 
                     m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);
                 }
@@ -397,4 +406,52 @@ void IntfsOrch::removeIp2MeRoute(const IpPrefix &ip_prefix)
     }
 
     SWSS_LOG_NOTICE("Remove packet action trap route ip:%s", ip_prefix.getIp().to_string().c_str());
+}
+
+void IntfsOrch::addDirectedBroadcast(const Port &port, const IpAddress &ip_addr)
+{
+    sai_status_t status;
+    sai_neighbor_entry_t neighbor_entry;
+    neighbor_entry.rif_id = port.m_rif_id;
+    neighbor_entry.switch_id = gSwitchId;
+    copy(neighbor_entry.ip_address, ip_addr);
+
+    sai_attribute_t neighbor_attr;
+    neighbor_attr.id = SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS;
+    memcpy(neighbor_attr.value.mac, MacAddress("ff:ff:ff:ff:ff:ff").getMac(), 6);
+
+    status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, 1, &neighbor_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to create broadcast entry %s rv:%d",
+                       ip_addr.to_string().c_str(), status);        return;
+    }
+
+    SWSS_LOG_NOTICE("Add broadcast route for ip:%s", ip_addr.to_string().c_str());
+}
+
+void IntfsOrch::removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr)
+{
+    sai_status_t status;
+    sai_neighbor_entry_t neighbor_entry;
+    neighbor_entry.rif_id = port.m_rif_id;
+    neighbor_entry.switch_id = gSwitchId;
+    copy(neighbor_entry.ip_address, ip_addr);
+
+    status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+        {
+            SWSS_LOG_ERROR("No broadcast entry found for %s", ip_addr.to_string().c_str());
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to remove broadcast entry %s rv:%d",
+                           ip_addr.to_string().c_str(), status);
+        }
+        return;
+    }
+
+    SWSS_LOG_NOTICE("Remove broadcast route ip:%s", ip_addr.to_string().c_str());
 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -424,7 +424,8 @@ void IntfsOrch::addDirectedBroadcast(const Port &port, const IpAddress &ip_addr)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create broadcast entry %s rv:%d",
-                       ip_addr.to_string().c_str(), status);        return;
+                       ip_addr.to_string().c_str(), status);
+        return;
     }
 
     SWSS_LOG_NOTICE("Add broadcast route for ip:%s", ip_addr.to_string().c_str());

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -45,6 +45,9 @@ private:
 
     void addIp2MeRoute(const IpPrefix &ip_prefix);
     void removeIp2MeRoute(const IpPrefix &ip_prefix);
+
+    void addDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
+    void removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
 };
 
 #endif /* SWSS_INTFSORCH_H */

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,12 +6,12 @@ SWSS Integration tests runs on docker-sonic-vs which runs on top of SAI virtual 
 
 # How to run the tests
 
-- Install docker and pytest on your dev machine
+- Install docker and pytest on your dev machine. In case "--system" option is not available, you can ignore the option and try.
     ```
     sudo pip install --system docker==2.6.1
     sudo pip install --system pytest==3.3.0
     ```
-- Compile and install swss common library
+- Compile and install swss common library. Install libhiredis prior to installing libswss.
     ````
     cd sonic-swss-common
     dpkg-buildpackage -us -uc -b

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,12 +6,12 @@ SWSS Integration tests runs on docker-sonic-vs which runs on top of SAI virtual 
 
 # How to run the tests
 
-- Install docker and pytest on your dev machine. In case "--system" option is not available, you can ignore the option and try.
+- Install docker and pytest on your dev machine. In case "--system" option is not available, ignore the option and try.
     ```
     sudo pip install --system docker==2.6.1
     sudo pip install --system pytest==3.3.0
     ```
-- Compile and install swss common library. Install libhiredis prior to installing libswss.
+- Compile and install swss common library
     ````
     cd sonic-swss-common
     dpkg-buildpackage -us -uc -b

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -1,0 +1,80 @@
+from swsscommon import swsscommon
+import time
+import re
+import json
+
+def test_DirectedBroadcast(dvs):
+
+    db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+    adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+    # create vlan in config db
+    tbl = swsscommon.Table(db, "VLAN", '|')
+    fvs = swsscommon.FieldValuePairs([("vlanid", "100")])
+    tbl.set("Vlan100", fvs)
+
+    # create a vlan member in config db
+    tbl = swsscommon.Table(db, "VLAN_MEMBER", '|')
+    fvs = swsscommon.FieldValuePairs([("tagging_mode", "tagged")])
+    tbl.set("Vlan100|Ethernet24", fvs)
+  
+    time.sleep(1)
+    
+    # create vlan interface in config db
+    tbl = swsscommon.Table(db, "VLAN_INTERFACE", '|')
+    fvs = swsscommon.FieldValuePairs([("family", "IPv4")])
+    tbl.set("Vlan100|192.169.0.1/27", fvs)
+    
+    time.sleep(1)
+    
+    # check vlan in asic db
+    atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
+    keys = atbl.getKeys()
+    vlan_oid = None
+
+    for key in keys:
+        if key == dvs.asicdb.default_vlan_id:
+            continue
+
+        (status, fvs) = atbl.get(key)
+        assert status == True
+
+        if fvs[0][0] == "SAI_VLAN_ATTR_VLAN_ID":
+            assert fvs[0][1] == '100'
+            vlan_oid = key
+
+    assert vlan_oid != None
+    
+    # check router interface in asic db
+    atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE")
+    keys = atbl.getKeys()
+    rif_oid = None
+    
+    for key in keys:
+        (status, fvs) = atbl.get(key)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_VLAN_ID":
+                assert vlan_oid == fv[1]
+                rif_oid = key
+    
+    assert rif_oid != None
+    
+    # check neighbor entry in asic db
+    atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+    keys = atbl.getKeys()
+    dir_bcast = False
+    
+    for key in keys:
+        neigh = json.loads(key)
+
+        if neigh['ip'] == "192.169.0.31":
+            dir_bcast = True
+            assert neigh['rif'] == rif_oid
+            (status, fvs) = atbl.get(key)
+            assert status == True
+            if fvs[0][0] == "SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS":
+                assert fvs[0][1] == "FF:FF:FF:FF:FF:FF"
+            
+    assert dir_bcast
+


### PR DESCRIPTION
Initial commit - Testing in progress. 
Pending- Add knob to enable/disable directed broadcast via configDB

Logs:
```
admin@z9100:~$ bcmcmd 'l3 l3table show'
Unit 0, free L3 table entries: 8185
Entry VRF IP address       Mac Address           INTF MOD PORT    CLASS HIT    H/W Index
1     0    10.0.0.63        00:00:00:00:00:00  100008    0    0         0 n      256  
5     0    192.168.0.31     ff:ff:ff:ff:ff:ff     5    0    0         0 n      896  

admin@z9100:~$ bcmcmd 'l3 intf show'
Free L3INTF entries: 8185
Unit  Intf  VRF Group VLAN    Source Mac     MTU TTL Tunnel InnerVlan  NATRealm
------------------------------------------------------------------
0     5     0     0     1000 4c:76:25:f0:89:40  16383 64   0     0     0    

admin@str-z9100-acs-2:~$ bcmcmd 'l3 defip show' | grep 192.168.0
24    0        192.168.0.1/32       00:00:00:00:00:00 100003    0     0     0    1 n
32792 0        192.168.0.0/27       00:00:00:00:00:00 100003    0     0     0    1 n

```
