### PR TITLE
Configdb neighbor restore during warmboot

### DIFF
--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -142,12 +142,12 @@ def set_neigh_in_kernel(ipclass, family, intf_idx, dst_ip, dmac):
     # so if the neighbor is active, it will become "reachable", otherwise, it will
     # stay at "stale" state and get aged out by kernel.
     try :
-        ipclass.neigh('add',
+        ipclass.neigh('replace',
             family=family_af_inet,
             dst=dst_ip,
             lladdr=dmac,
             ifindex=intf_idx,
-            state=ndmsg.states['stale'])
+            state=ndmsg.states['reachable'])
 
     # If neigh exists, log it but no exception raise, other exceptions, raise
     except NetlinkError as e:


### PR DESCRIPTION
**What I did**
Replace Neigh entries if it exists and add as state reachable during warmboot neighbor restoration. 

**Why I did it**
During warmboot, `restore_neighbors.py` restores the APP_DB entries as stale. This will be overwritten by `nbrmgrd `to trigger ARP but in case of Vlan, the member ports won't be added until later in the initialization, the packets won't get forwarded. This results in neigh entry to FAIL state and disrupts the warmboot requirements. Logs are captured below with timestamps of various events

**How I verified it**

**Details if related**
```
admin@str-a7060cx-acs-1:~$ show vlan brief
+-----------+------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address       | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+==================+============+================+=======================+
|       200 | 192.168.200.1/24 | Ethernet2  | tagged         |                       |
```
```
admin@str-a7060cx-acs-1:~$ ip neigh show
192.168.200.4 dev Vlan200 lladdr 24:8a:07:4c:f5:01 REACHABLE
```

```
Aug  8 23:04:48.742231 str-a7060cx-acs-1 INFO swss#supervisord: restore_neighbors WARNING:__main__:Sending Neigh with family: IPv4, intf_idx: 11, ip: 192.168.200.4, mac: 24:8a:07:4c:f5:01
Aug  8 23:04:50.142733 str-a7060cx-acs-1 NOTICE swss#nbrmgrd: :- main: --- Starting nbrmgrd ---
Aug  8 23:04:50.156758 str-a7060cx-acs-1 NOTICE swss#nbrmgrd: :- main: starting main loop
Aug  8 23:04:50.157090 str-a7060cx-acs-1 NOTICE swss#nbrmgrd: :- doTask: Neigh entry added for 'Vlan200|192.168.200.4'
Aug  8 23:04:59.010287 str-a7060cx-acs-1 NOTICE swss#portmgrd: :- doTask: Configure Ethernet2 MTU to 9100
Aug  8 23:04:59.024399 str-a7060cx-acs-1 NOTICE swss#portmgrd: :- doTask: Configure Ethernet2 admin status to up
Aug  8 23:05:09.207801 str-a7060cx-acs-1 NOTICE swss#orchagent: :- initializePort: Initializing port alias:Ethernet2 pid:1000000000011
Aug  8 23:05:09.215846 str-a7060cx-acs-1 NOTICE swss#orchagent: :- addHostIntfs: Create host interface for port Ethernet2
Aug  8 23:05:09.218177 str-a7060cx-acs-1 NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status UP to host interface Ethernet2
Aug  8 23:05:09.218503 str-a7060cx-acs-1 NOTICE swss#orchagent: :- initPort: Initialized port Ethernet2
n
Aug  8 23:05:09.644671 str-a7060cx-acs-1 NOTICE swss#orchagent: :- addNextHop: Created next hop 192.168.200.4 on Vlan200

Aug  8 23:05:14.719059 str-a7060cx-acs-1 NOTICE swss#orchagent: :- addBridgePort: Add bridge port Ethernet2 to default 1Q bridge
Aug  8 23:05:14.719473 str-a7060cx-acs-1 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet2 to VLAN Vlan1000 vid:1000 pid1000000000011
Aug  8 23:05:24.871698 str-a7060cx-acs-1 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet2 oper state set from up to up

```



