### PR TITLE
[nbrmgr]: Reconcile pending NEIGH_RESOLVE_TABLE entries on restart

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -258,6 +258,11 @@ jobs:
   - script: |
       RUSTFLAGS=-Dwarnings cargo test
     displayName: "Test countersyncd"
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/*_tr.xml'
+      testRunTitle: gtest
+    condition: and(succeededOrFailed(), eq('${{ parameters.asan }}', false))
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive swss debian packages"

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -104,11 +104,12 @@ jobs:
     clean: true
     submodules: true
   - script: |
+      set -xe
       sudo apt-get update
       sudo apt-get install -y \
         libhiredis-dev \
         libzmq3-dev \
-        swig4.0 \
+        swig \
         libdbus-1-dev \
         libteam-dev
       sudo pip3 install lcov_cobertura

--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -75,6 +75,7 @@ build_and_install_kmodule()
     mv .config .config.bk
     cp /boot/config-$(uname -r) .config
     grep NET_TEAM .config.bk >> .config
+    make olddefconfig
     make VERSION=$VERSION PATCHLEVEL=$PATCHLEVEL SUBLEVEL=$SUBLEVEL EXTRAVERSION=-${EXTRAVERSION} LOCALVERSION=-${LOCALVERSION} modules_prepare
     cp /usr/src/linux-headers-$(uname -r)/Module.symvers .
     make -j$(nproc) M=drivers/net/team

--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,10 @@ tests/tests.log
 tests/tests.trs
 tests/mock_tests/**/*log
 tests/mock_tests/**/*trs
+tests/mock_tests/**/*_tr.xml
 orchagent/p4orch/tests/p4orch_tests
+orchagent/p4orch/tests/*_tr.xml
+
 
 # Build Environment #
 ###################

--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -100,8 +100,15 @@ void BufferMgr::readPgProfileLookupFile(string file)
 
 task_process_status BufferMgr::doCableTask(string port, string cable_length)
 {
-    m_cableLenLookup[port] = cable_length;
-    SWSS_LOG_INFO("Cable length set to %s for port %s", m_cableLenLookup[port].c_str(), port.c_str());
+
+    if (cable_length != "None" && m_cableLenLookup[port] != cable_length)
+    {
+        m_cableLenLookup[port] = cable_length;
+        SWSS_LOG_INFO("Cable length set to %s for port %s", m_cableLenLookup[port].c_str(), port.c_str());
+        // The return status is ignored
+        doSpeedUpdateTask(port);
+    }
+
     return task_process_status::task_success;
 }
 

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -247,12 +247,13 @@ void NbrMgr::reconcileNeighResolveTable(DBConnector *appDb)
 
     for (const auto &key : keys)
     {
-        vector<string> parsedKeys = parseAliasIp(key, ":");
-        if (parsedKeys.size() != 2)
+        if (key.find(':') == string::npos)
         {
             SWSS_LOG_ERROR("Failed to parse NEIGH_RESOLVE_TABLE key '%s'", key.c_str());
             continue;
         }
+
+        vector<string> parsedKeys = parseAliasIp(key, ":");
 
         MacAddress mac;
         IpAddress ip(parsedKeys[1]);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -245,27 +245,38 @@ void NbrMgr::reconcileNeighResolveTable(DBConnector *appDb)
 
     SWSS_LOG_NOTICE("Reconciling %zu pending entries in NEIGH_RESOLVE_TABLE", keys.size());
 
+    string tableSeparator = neighResolveTable.getTableNameSeparator();
+
     for (const auto &key : keys)
     {
-        if (key.find(':') == string::npos)
+        try
         {
-            SWSS_LOG_ERROR("Failed to parse NEIGH_RESOLVE_TABLE key '%s'", key.c_str());
+            if (key.find(tableSeparator) == string::npos)
+            {
+                SWSS_LOG_ERROR("Failed to parse NEIGH_RESOLVE_TABLE key '%s'", key.c_str());
+                continue;
+            }
+
+            vector<string> parsedKeys = parseAliasIp(key, tableSeparator.c_str());
+
+            MacAddress mac;
+            IpAddress ip(parsedKeys[1]);
+            string alias(parsedKeys[0]);
+
+            if (!setNeighbor(alias, ip, mac))
+            {
+                SWSS_LOG_WARN("Neigh entry resolve failed for '%s' during reconciliation", key.c_str());
+            }
+            else
+            {
+                SWSS_LOG_INFO("Reconciled NEIGH_RESOLVE entry '%s'", key.c_str());
+            }
+        }
+        catch (const std::exception &e)
+        {
+            SWSS_LOG_ERROR("Exception during reconciliation of NEIGH_RESOLVE_TABLE key '%s': %s",
+                           key.c_str(), e.what());
             continue;
-        }
-
-        vector<string> parsedKeys = parseAliasIp(key, ":");
-
-        MacAddress mac;
-        IpAddress ip(parsedKeys[1]);
-        string alias(parsedKeys[0]);
-
-        if (!setNeighbor(alias, ip, mac))
-        {
-            SWSS_LOG_WARN("Neigh entry resolve failed for '%s' during reconciliation", key.c_str());
-        }
-        else
-        {
-            SWSS_LOG_INFO("Reconciled NEIGH_RESOLVE entry '%s'", key.c_str());
         }
     }
 }

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -65,7 +65,10 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
                               TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
     auto consumer = new Consumer(consumerStateTable, this, APP_NEIGH_RESOLVE_TABLE_NAME);
     Orch::addExecutor(consumer);
-          
+
+    /* Reconcile any pending entries in NEIGH_RESOLVE_TABLE from before restart */
+    reconcileNeighResolveTable(appDb);
+
     string swtype;
     Table cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
     if(cfgDeviceMetaDataTable.hget("localhost", "switch_type", swtype))
@@ -224,6 +227,46 @@ vector<string> NbrMgr::parseAliasIp(const string &app_db_nbr_tbl_key, const char
     ret.push_back(ip_address);
 
     return ret;
+}
+
+void NbrMgr::reconcileNeighResolveTable(DBConnector *appDb)
+{
+    SWSS_LOG_ENTER();
+
+    Table neighResolveTable(appDb, APP_NEIGH_RESOLVE_TABLE_NAME);
+    vector<string> keys;
+    neighResolveTable.getKeys(keys);
+
+    if (keys.empty())
+    {
+        SWSS_LOG_INFO("No pending entries in NEIGH_RESOLVE_TABLE");
+        return;
+    }
+
+    SWSS_LOG_NOTICE("Reconciling %zu pending entries in NEIGH_RESOLVE_TABLE", keys.size());
+
+    for (const auto &key : keys)
+    {
+        vector<string> parsedKeys = parseAliasIp(key, ":");
+        if (parsedKeys.size() != 2)
+        {
+            SWSS_LOG_ERROR("Failed to parse NEIGH_RESOLVE_TABLE key '%s'", key.c_str());
+            continue;
+        }
+
+        MacAddress mac;
+        IpAddress ip(parsedKeys[1]);
+        string alias(parsedKeys[0]);
+
+        if (!setNeighbor(alias, ip, mac))
+        {
+            SWSS_LOG_WARN("Neigh entry resolve failed for '%s' during reconciliation", key.c_str());
+        }
+        else
+        {
+            SWSS_LOG_INFO("Reconciled NEIGH_RESOLVE entry '%s'", key.c_str());
+        }
+    }
 }
 
 void NbrMgr::doResolveNeighTask(Consumer &consumer)

--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -23,6 +23,7 @@ public:
     bool isNeighRestoreDone();
 
 private:
+    void reconcileNeighResolveTable(DBConnector *appDb);
     bool isIntfStateOk(const std::string &alias);
     bool setNeighbor(const std::string& alias, const IpAddress& ip, const MacAddress& mac);
 

--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -10,9 +10,9 @@
 #include "warm_restart.h"
 
 #define VRF_TABLE_START 1001
-#define VRF_TABLE_END 2000
+#define VRF_TABLE_END 5097
 #define TABLE_LOCAL_PREF 1001 // after l3mdev-table
-#define MGMT_VRF_TABLE_ID 5000
+#define MGMT_VRF_TABLE_ID 6000
 #define MGMT_VRF          "mgmt"
 
 using namespace swss;

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -76,6 +76,11 @@ impl NetlinkMessageParser {
         }
     }
 
+    /// Mirrors `NLMSG_ALIGN` from `linux/netlink.h` by rounding lengths up to the next 4-byte boundary.
+    fn nlmsg_align(len: usize) -> usize {
+        (len + 3) & !3
+    }
+
     /// Parse buffer that may contain multiple complete and/or incomplete netlink messages
     /// Returns a vector of complete message payloads, where each payload represents 
     /// one complete netlink message (which contains one complete IPFIX message)
@@ -131,9 +136,14 @@ impl NetlinkMessageParser {
                 break;
             }
 
-            // Extract complete message
+            let aligned_nl_len = Self::nlmsg_align(nl_len);
+
+            // Extract complete message without trailing alignment padding
             let message_data = self.incomplete_buffer[offset..offset + nl_len].to_vec();
-            debug!("Found complete message: offset={}, length={}", offset, nl_len);
+            debug!(
+                "Found complete message: offset={}, length={}, aligned_length={}",
+                offset, nl_len, aligned_nl_len
+            );
 
             // Extract payload from this message
             match Self::extract_payload_from_slice(&message_data) {
@@ -147,7 +157,8 @@ impl NetlinkMessageParser {
                 }
             }
 
-            offset += nl_len;
+            let remaining = self.incomplete_buffer.len() - offset;
+            offset += usize::min(aligned_nl_len, remaining);
         }
 
         // Keep remaining incomplete data for next recv
@@ -1017,6 +1028,15 @@ pub mod test {
         msg
     }
 
+    fn append_aligned_mock_netlink_message(buffer: &mut Vec<u8>, payload: &[u8]) {
+        let msg = create_mock_netlink_message(payload);
+        let msg_len = 20 + payload.len();
+        let aligned_len = NetlinkMessageParser::nlmsg_align(msg_len);
+
+        buffer.extend_from_slice(&msg[..msg_len]);
+        buffer.resize(buffer.len() + (aligned_len - msg_len), 0);
+    }
+
     // Use atomic counter instead of unsafe static mut for thread safety
     static SOCKET_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -1255,6 +1275,25 @@ pub mod test {
         let payload2_str = String::from_utf8(messages[1].to_vec()).unwrap();
         assert_eq!(payload1_str, "MESSAGE1");
         assert_eq!(payload2_str, "MESSAGE2");
+    }
+
+    /// Tests handling multiple aligned messages where the first message length
+    /// is not a multiple of 4 and therefore requires netlink padding.
+    #[test]
+    fn test_multiple_aligned_messages_in_buffer() {
+        let mut combined_buffer = Vec::new();
+
+        append_aligned_mock_netlink_message(&mut combined_buffer, b"A");
+        append_aligned_mock_netlink_message(&mut combined_buffer, b"SECOND");
+
+        let mut parser = NetlinkMessageParser::new();
+        let result = parser.parse_buffer(&combined_buffer);
+        assert!(result.is_ok());
+
+        let messages = result.unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(String::from_utf8(messages[0].to_vec()).unwrap(), "A");
+        assert_eq!(String::from_utf8(messages[1].to_vec()).unwrap(), "SECOND");
     }
 
     /// Tests handling fragmented messages across multiple recv operations.

--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -20,7 +20,12 @@ from pyroute2.netlink.rtnl import ndmsg
 from socket import AF_INET,AF_INET6
 import logging
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-from scapy.all import conf, in6_getnsma, inet_pton, inet_ntop, in6_getnsmac, get_if_hwaddr, Ether, ARP, IPv6, ICMPv6ND_NS, ICMPv6NDOptSrcLLAddr
+
+# Avoid long startup delays when route tables are large.
+from scapy.config import conf
+conf.route_autoload = False
+conf.route6_autoload = False
+from scapy.all import in6_getnsma, inet_pton, inet_ntop, in6_getnsmac, get_if_hwaddr, Ether, ARP, IPv6, ICMPv6ND_NS, ICMPv6NDOptSrcLLAddr
 from swsscommon import swsscommon
 import errno
 import syslog

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1163,30 +1163,34 @@ task_process_status BufferOrch::processQueuePost(const QueueTask& task)
              * so we added a map that will help us to know what was the last command for this port and priority -
              * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
              * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
-            if (op == SET_COMMAND)
+            /* for voq switches the buffer configuration is applied on the VOQ which is applicable on the system ports
+             * system ports are not dynamically created/deleted so no need to maintain ref counter */
+            if (gMySwitchType != "voq")
             {
-                if (queue_port_flags[port_name][ind] != SET_COMMAND)
+                if (op == SET_COMMAND)
                 {
-                    /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
-                    gPortsOrch->increasePortRefCount(port_name);
+                    if (queue_port_flags[port_name][ind] != SET_COMMAND)
+                    {
+                        /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
+                        gPortsOrch->increasePortRefCount(port_name);
+                    }
                 }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (queue_port_flags[port_name][ind] == SET_COMMAND)
-		{
-                    /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
-                    gPortsOrch->decreasePortRefCount(port_name);
+                else if (op == DEL_COMMAND)
+                {
+                    if (queue_port_flags[port_name][ind] == SET_COMMAND)
+                    {
+                        /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
+                        gPortsOrch->decreasePortRefCount(port_name);
+                    }
                 }
+                else
+                {
+                    SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+                /* save the last command (set or delete) */
+                queue_port_flags[port_name][ind] = op;
             }
-            else
-            {
-                SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
-                return task_process_status::task_invalid_entry;
-            }
-            /* save the last command (set or delete) */
-            queue_port_flags[port_name][ind] = op;
-
         }
     }
 

--- a/orchagent/dash/dashhaorch.h
+++ b/orchagent/dash/dashhaorch.h
@@ -1,6 +1,7 @@
 #ifndef DASHHAORCH_H
 #define DASHHAORCH_H
 #include <map>
+#include <mutex>
 
 #include "dbconnector.h"
 #include "dashorch.h"
@@ -71,6 +72,7 @@ protected:
     bool setHaScopeFlowReconcileRequest(const  std::string &key);
     bool setHaScopeActivateRoleRequest(const std::string &key);
     bool setHaScopeDisabled(const std::string &key, bool disabled);
+    virtual bool isHaScopeAdminStateAttrSupported();
     bool setEniHaScopeId(const sai_object_id_t eni_id, const sai_object_id_t ha_scope_id);
     bool register_ha_set_notifier();
     bool register_ha_scope_notifier();
@@ -106,6 +108,9 @@ protected:
 
     swss::NotificationConsumer* m_haSetNotificationConsumer;
     swss::NotificationConsumer* m_haScopeNotificationConsumer;
+
+    bool m_ha_scope_admin_state_attr_supported = false;
+    std::once_flag m_ha_scope_admin_state_attr_once_flag;
 
 public:
     const HaSetTable& getHaSetEntries() const { return m_ha_set_entries; };

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -99,6 +99,32 @@ bool DashOrch::hasApplianceEntry()
     return !appliance_entries_.empty();
 }
 
+bool DashOrch::isHaFlowOwnerAttrSupported()
+{
+    SWSS_LOG_ENTER();
+
+    std::call_once(m_ha_flow_owner_attr_once_flag, [this]() {
+        sai_attr_capability_t capability;
+        sai_status_t status = sai_query_attribute_capability(
+                gSwitchId,
+                (sai_object_type_t)SAI_OBJECT_TYPE_ENI,
+                SAI_ENI_ATTR_IS_HA_FLOW_OWNER,
+                &capability);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_WARN("Could not query SAI_ENI_ATTR_IS_HA_FLOW_OWNER capability: %d", status);
+            m_ha_flow_owner_attr_supported = false;
+        }
+        else
+        {
+            m_ha_flow_owner_attr_supported = capability.set_implemented || capability.create_implemented;
+        }
+    });
+
+    return m_ha_flow_owner_attr_supported;
+}
+
 bool DashOrch::addApplianceEntry(const string& appliance_id, const dash::appliance::Appliance &entry)
 {
     SWSS_LOG_ENTER();
@@ -663,25 +689,31 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
             eni_attrs.push_back(eni_attr);
             SWSS_LOG_INFO("Setting HA Scope ID %" PRIx64 " for ENI %s", ha_scope_entry.ha_scope_id, eni.c_str());
 
-            // Set HA flow owner based on HA role
-            eni_attr.id = SAI_ENI_ATTR_IS_HA_FLOW_OWNER;
-            if (ha_scope_entry.metadata.ha_role() == dash::types::HA_ROLE_ACTIVE || ha_scope_entry.metadata.ha_role() == dash::types::HA_ROLE_STANDALONE)
+            if (isHaFlowOwnerAttrSupported())
             {
-                eni_attr.value.booldata = true;
-                SWSS_LOG_INFO("Setting HA flow owner to true (ACTIVE) for ENI %s", eni.c_str());
-            }
-            else if (ha_scope_entry.metadata.ha_role() == dash::types::HA_ROLE_STANDBY)
-            {
-                eni_attr.value.booldata = false;
-                SWSS_LOG_INFO("Setting HA flow owner to false (STANDBY) for ENI %s", eni.c_str());
+                eni_attr.id = SAI_ENI_ATTR_IS_HA_FLOW_OWNER;
+                if (ha_scope_entry.metadata.ha_role() == dash::types::HA_ROLE_ACTIVE || ha_scope_entry.metadata.ha_role() == dash::types::HA_ROLE_STANDALONE)
+                {
+                    eni_attr.value.booldata = true;
+                    SWSS_LOG_INFO("Setting HA flow owner to true (ACTIVE) for ENI %s", eni.c_str());
+                }
+                else if (ha_scope_entry.metadata.ha_role() == dash::types::HA_ROLE_STANDBY)
+                {
+                    eni_attr.value.booldata = false;
+                    SWSS_LOG_INFO("Setting HA flow owner to false (STANDBY) for ENI %s", eni.c_str());
+                }
+                else
+                {
+                    // For other roles (DEAD, SWITCHING_TO_ACTIVE), default to false
+                    eni_attr.value.booldata = false;
+                    SWSS_LOG_INFO("Setting HA flow owner to false (role: %s) for ENI %s", dash::types::HaRole_Name(ha_scope_entry.metadata.ha_role()).c_str(), eni.c_str());
+                }
+                eni_attrs.push_back(eni_attr);
             }
             else
             {
-                // For other roles (DEAD, SWITCHING_TO_ACTIVE), default to false
-                eni_attr.value.booldata = false;
-                SWSS_LOG_INFO("Setting HA flow owner to false (role: %s) for ENI %s", dash::types::HaRole_Name(ha_scope_entry.metadata.ha_role()).c_str(), eni.c_str());
+                SWSS_LOG_INFO("SAI_ENI_ATTR_IS_HA_FLOW_OWNER not supported, skipping for ENI %s", eni.c_str());
             }
-            eni_attrs.push_back(eni_attr);
         }
         else
         {

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -102,6 +102,8 @@ private:
     bool removeQosEntry(const std::string& qos_name);
     bool setEniRoute(const std::string& eni, const dash::eni_route::EniRoute& entry);
     bool removeEniRoute(const std::string& eni);
+protected:
+    virtual bool isHaFlowOwnerAttrSupported();
 
 private:
 
@@ -172,6 +174,8 @@ private:
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;
     DashHaOrch* m_dash_ha_orch = nullptr;
+    bool m_ha_flow_owner_attr_supported = false;
+    std::once_flag m_ha_flow_owner_attr_once_flag;
 
     void addEniMapEntry(sai_object_id_t oid, const std::string& name);
     void removeEniMapEntry(sai_object_id_t oid, const std::string& name);

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -38,6 +38,7 @@ const unordered_map<CounterType, string> FlexCounterManager::counter_id_field_lo
 {
     { CounterType::PORT_DEBUG,          PORT_DEBUG_COUNTER_ID_LIST },
     { CounterType::PORT_PHY_ATTR,       PORT_PHY_ATTR_ID_LIST },
+    { CounterType::PORT_PHY_SERDES_ATTR,PORT_PHY_SERDES_ATTR_ID_LIST },
     { CounterType::SWITCH_DEBUG,        SWITCH_DEBUG_COUNTER_ID_LIST },
     { CounterType::PORT,                PORT_COUNTER_ID_LIST },
     { CounterType::QUEUE,               QUEUE_COUNTER_ID_LIST },

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -28,6 +28,7 @@ enum class CounterType
 {
     PORT,
     PORT_PHY_ATTR,
+    PORT_PHY_SERDES_ATTR,
     QUEUE,
     QUEUE_ATTR,
     PRIORITY_GROUP,

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -45,6 +45,7 @@ int gFlexCounterDelaySec;
 #define BUFFER_POOL_WATERMARK_KEY   "BUFFER_POOL_WATERMARK"
 #define PORT_KEY                    "PORT"
 #define PORT_PHY_ATTR_KEY           "PORT_PHY_ATTR"
+#define PORT_PHY_SERDES_ATTR_KEY    "PORT_PHY_SERDES_ATTR"
 #define PORT_BUFFER_DROP_KEY        "PORT_BUFFER_DROP"
 #define QUEUE_KEY                   "QUEUE"
 #define QUEUE_WATERMARK             "QUEUE_WATERMARK"
@@ -66,6 +67,7 @@ unordered_map<string, string> flexCounterGroupMap =
 {
     {"PORT", PORT_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {"PORT_PHY_ATTR", PORT_PHY_ATTR_FLEX_COUNTER_GROUP},
+    {"PORT_PHY_SERDES_ATTR", PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP},
     {"PORT_RATES", PORT_RATE_COUNTER_FLEX_COUNTER_GROUP},
     {"DEBUG_MONITOR_COUNTER", DEBUG_DROP_MONITOR_FLEX_COUNTER_GROUP},
     {"PORT_BUFFER_DROP", PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP},
@@ -203,6 +205,11 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                             setFlexCounterGroupPollInterval(flexCounterGroupMap[key], value, true);
                         }
                     }
+                    // PORT_PHY_ATTR_KEY and PORT_PHY_SERDES_ATTR_KEY share the 'counterpoll phy' knob
+                    if (key == PORT_PHY_ATTR_KEY)
+                    {
+                        setFlexCounterGroupPollInterval(flexCounterGroupMap[PORT_PHY_SERDES_ATTR_KEY], value);
+                    }
                 }
                 else if (field == BULK_CHUNK_SIZE_FIELD)
                 {
@@ -326,15 +333,31 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                     }
                     if (gPortsOrch && (key == PORT_PHY_ATTR_KEY))
                     {
-                        if(value == "enable" && !m_port_phy_attr_enabled)
+                        if(value == "enable")
                         {
-                            m_port_phy_attr_enabled = true;
-                            gPortsOrch->generatePortPhyAttrCounterMap();
+                            if (!m_port_phy_attr_enabled)
+                            {
+                                m_port_phy_attr_enabled = true;
+                                gPortsOrch->generatePortPhyAttrCounterMap();
+                            }
+                            if (!m_port_phy_serdes_attr_enabled)
+                            {
+                                m_port_phy_serdes_attr_enabled = true;
+                                gPortsOrch->generatePortPhySerdesAttrCounterMap();
+                            }
                         }
-                        if (value == "disable" && m_port_phy_attr_enabled)
+                        if (value == "disable")
                         {
-                            gPortsOrch->clearPortPhyAttrCounterMap();
-                            m_port_phy_attr_enabled = false;
+                            if (m_port_phy_attr_enabled)
+                            {
+                                gPortsOrch->clearPortPhyAttrCounterMap();
+                                m_port_phy_attr_enabled = false;
+                            }
+                            if (m_port_phy_serdes_attr_enabled)
+                            {
+                                gPortsOrch->clearPortPhySerdesAttrCounterMap();
+                                m_port_phy_serdes_attr_enabled = false;
+                            }
                         }
                     }
                     if (gSwitchOrch && (key == SWITCH_KEY) && (value == "enable"))
@@ -355,6 +378,11 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         {
                             setFlexCounterGroupOperation(flexCounterGroupMap[key], value, true);
                         }
+                    }
+                    // PORT_PHY_ATTR_KEY and PORT_PHY_SERDES_ATTR_KEY share the 'counterpoll phy' knob
+                    if (key == PORT_PHY_ATTR_KEY)
+                    {
+                        setFlexCounterGroupOperation(flexCounterGroupMap[PORT_PHY_SERDES_ATTR_KEY], value);
                     }
                 }
                 else
@@ -403,6 +431,11 @@ bool FlexCounterOrch::getPortCountersState() const
 bool FlexCounterOrch::getPortPhyAttrCounterState() const
 {
     return m_port_phy_attr_enabled;
+}
+
+bool FlexCounterOrch::getPortPhySerdesAttrCountersState() const
+{
+    return m_port_phy_serdes_attr_enabled;
 }
 
 bool FlexCounterOrch::getPortBufferDropCountersState() const

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -58,6 +58,7 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortPhyAttrCounterState() const;
+    bool getPortPhySerdesAttrCountersState() const;
     bool getPortBufferDropCountersState() const;
     bool getQueueCountersState() const;
     bool getQueueWatermarkCountersState() const;
@@ -76,6 +77,7 @@ private:
     void handleDeviceMetadataTable(Consumer &consumer);
     bool m_port_counter_enabled = false;
     bool m_port_phy_attr_enabled = false;
+    bool m_port_phy_serdes_attr_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
     bool m_queue_enabled = false;
     bool m_queue_watermark_enabled = false;

--- a/orchagent/high_frequency_telemetry/hftelprofile.cpp
+++ b/orchagent/high_frequency_telemetry/hftelprofile.cpp
@@ -955,47 +955,36 @@ void HFTelProfile::updateTemplates(sai_object_id_t tam_tel_type_obj)
         SWSS_LOG_THROW("The object type is not found");
     }
 
-    // Estimate the template size
-    auto counters = m_sai_tam_counter_subscription_objs.find(object_type);
-    if (counters == m_sai_tam_counter_subscription_objs.end())
-    {
-        SWSS_LOG_THROW("The counter subscription object is not found");
-    }
-    size_t counters_count = 0;
-    for (const auto &item : counters->second)
-    {
-        counters_count += item.second.size();
-    }
-
-    const size_t COUNTER_SIZE (8LLU);
-    const size_t IPFIX_TEMPLATE_MAX_SIZE (0xffffLLU);
-    const size_t IPFIX_HEADER_SIZE (16LLU);
-    const size_t IPFIX_TEMPLATE_METADATA_SIZE (12LLU);
-    const size_t IPFIX_TEMPLATE_MAX_STATS_COUNT (((IPFIX_TEMPLATE_MAX_SIZE - IPFIX_HEADER_SIZE - IPFIX_TEMPLATE_METADATA_SIZE) / COUNTER_SIZE) - 1LLU);
-    size_t estimated_template_size = (counters_count / IPFIX_TEMPLATE_MAX_STATS_COUNT + 1) * IPFIX_TEMPLATE_MAX_SIZE;
-
-    vector<uint8_t> buffer(estimated_template_size, 0);
-
-    sai_attribute_t attr;
+    // Query the required buffer size first by passing count=0 and list=nullptr,
+    // then allocate and fetch the actual data.
+    sai_attribute_t attr{};
     attr.id = SAI_TAM_TEL_TYPE_ATTR_IPFIX_TEMPLATES;
-    attr.value.u8list.count = static_cast<uint32_t>(buffer.size());
-    attr.value.u8list.list = buffer.data();
+    attr.value.u8list.count = 0;
+    attr.value.u8list.list = nullptr;
 
     auto status = sai_tam_api->get_tam_tel_type_attribute(tam_tel_type_obj, 1, &attr);
-    if (status == SAI_STATUS_BUFFER_OVERFLOW)
+    if (status != SAI_STATUS_SUCCESS && status != SAI_STATUS_BUFFER_OVERFLOW)
     {
-        buffer.resize(attr.value.u8list.count);
-        attr.value.u8list.list = buffer.data();
-        status = sai_tam_api->get_tam_tel_type_attribute(tam_tel_type_obj, 1, &attr);
-    }
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_THROW("Failed to get the TAM telemetry type object %s attributes: %d",
+        SWSS_LOG_THROW("Failed to query the IPFIX template size for TAM telemetry type object %s: %d",
                        sai_serialize_object_id(tam_tel_type_obj).c_str(), status);
     }
 
-    buffer.resize(attr.value.u8list.count);
+    vector<uint8_t> buffer;
+    if (status == SAI_STATUS_BUFFER_OVERFLOW && attr.value.u8list.count > 0)
+    {
+        buffer.resize(attr.value.u8list.count, 0);
+        attr.value.u8list.list = buffer.data();
+        status = sai_tam_api->get_tam_tel_type_attribute(tam_tel_type_obj, 1, &attr);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_THROW("Failed to get the TAM telemetry type object %s attributes: %d",
+                           sai_serialize_object_id(tam_tel_type_obj).c_str(), status);
+        }
+
+        // SAI may return fewer bytes than originally requested.
+        buffer.resize(attr.value.u8list.count);
+    }
 
     m_sai_tam_tel_type_templates[object_type] = move(buffer);
 }

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -264,9 +264,9 @@ ReturnCode AclRuleManager::setUpUserDefinedTraps()
         auto trap_group_it = trapGroupMap.find(GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(queue_num));
         if (trap_group_it == trapGroupMap.end())
         {
-            LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-                                 << "Trap group was not found given trap group name: "
-                                 << GENL_PACKET_TRAP_GROUP_NAME_PREFIX << queue_num);
+	    SWSS_LOG_INFO("Trap group was not found given trap group name: %s%d",
+                    GENL_PACKET_TRAP_GROUP_NAME_PREFIX, queue_num);
+              continue;
         }
         const sai_object_id_t trap_group_oid = trap_group_it->second;
         auto hostif_oid_it = trapGroupHostIfMap.find(trap_group_oid);
@@ -322,7 +322,7 @@ ReturnCode AclRuleManager::setUpUserDefinedTraps()
         }
         m_p4OidMapper->setOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP, std::to_string(queue_num),
                               udt_hostif.user_defined_trap, /*ref_count=*/1);
-        m_userDefinedTraps.push_back(udt_hostif);
+	m_userDefinedTraps[queue_num] = udt_hostif;
         SWSS_LOG_NOTICE("Created user defined trap for QUEUE number %d: %s", queue_num,
                         sai_serialize_object_id(udt_hostif.user_defined_trap).c_str());
     }
@@ -333,15 +333,20 @@ ReturnCode AclRuleManager::cleanUpUserDefinedTraps()
 {
     SWSS_LOG_ENTER();
 
-    for (size_t queue_num = 1; queue_num <= m_userDefinedTraps.size(); queue_num++)
-    {
-        CHECK_ERROR_AND_LOG_AND_RETURN(
-            sai_hostif_api->remove_hostif_table_entry(m_userDefinedTraps[queue_num - 1].hostif_table_entry),
-            "Failed to create hostif table entry.");
-        m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP, std::to_string(queue_num));
-        sai_hostif_api->remove_hostif_user_defined_trap(m_userDefinedTraps[queue_num - 1].user_defined_trap);
-        m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP, std::to_string(queue_num));
+    const auto trapGroupMap = m_coppOrch->getTrapGroupMap();
+    for (const auto& udt_it : m_userDefinedTraps) {
+        CHECK_ERROR_AND_LOG_AND_RETURN(sai_hostif_api->remove_hostif_table_entry(
+                                       fvValue(udt_it).hostif_table_entry),
+                                       "Failed to remove hostif table entry.");
+
+        m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
+                                        std::to_string(fvField(udt_it)));
+        sai_hostif_api->remove_hostif_user_defined_trap(
+            fvValue(udt_it).user_defined_trap);
+        m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
+                                std::to_string(fvField(udt_it)));
     }
+
     m_userDefinedTraps.clear();
     return ReturnCode();
 }
@@ -1384,7 +1389,15 @@ ReturnCode AclRuleManager::setActionValue(const sai_acl_entry_attr_t attr_name,
                        << QuotedVar(acl_rule->acl_table_name)
                        << ". Queue number should >= 1 and <= " << m_userDefinedTraps.size();
             }
-            value->aclaction.parameter.oid = m_userDefinedTraps[queue_num - 1].user_defined_trap;
+	    const auto udt_it = m_userDefinedTraps.find(queue_num);
+            if (udt_it == m_userDefinedTraps.end()) {
+          	return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                 << "Invalid CPU queue number " << QuotedVar(attr_value)
+                 << " for " << QuotedVar(acl_rule->acl_table_name)
+                 << ". Queue number " << to_string(queue_num)
+                 << " does not have UserDefinedTrap configured";
+            }
+	    value->aclaction.parameter.oid = udt_it->second.user_defined_trap;
             acl_rule->action_qos_queue_num = queue_num;
         }
         catch (std::exception &e)

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -157,7 +157,7 @@ class AclRuleManager : public ObjectManagerInterface
     std::deque<swss::KeyOpFieldsValuesTuple> m_entries;
     std::unique_ptr<swss::DBConnector> m_countersDb;
     std::unique_ptr<swss::Table> m_countersTable;
-    std::vector<P4UserDefinedTrapHostifTableEntry> m_userDefinedTraps;
+    std::map<int, P4UserDefinedTrapHostifTableEntry> m_userDefinedTraps;
 
     friend class AclTableManager;
     friend class p4orch::test::AclManagerTest;

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -69,6 +69,7 @@ struct P4AclMeter
     sai_uint64_t cburst;
     sai_uint64_t pir;
     sai_uint64_t pburst;
+    std::string policer_label;
 
     std::map<sai_policer_attr_t, sai_packet_action_t> packet_color_actions;
 

--- a/orchagent/p4orch/l3_multicast_manager.cpp
+++ b/orchagent/p4orch/l3_multicast_manager.cpp
@@ -32,6 +32,7 @@ extern sai_object_id_t gSwitchId;
 extern sai_object_id_t gVirtualRouterId;
 extern sai_ipmc_group_api_t* sai_ipmc_group_api;
 extern sai_router_interface_api_t* sai_router_intfs_api;
+extern sai_bridge_api_t* sai_bridge_api;
 
 extern PortsOrch* gPortsOrch;
 
@@ -820,11 +821,10 @@ ReturnCode L3MulticastManager::validateL3SetMulticastRouterInterfaceEntry(
            << "RIF was not assigned before updating multicast router "
               "interface "
               "entry with keys "
-           << QuotedVar(
-                  multicast_router_interface_entry.multicast_replica_port)
+	   << QuotedVar(multicast_router_interface_entry.multicast_replica_port)
            << " and "
-           << QuotedVar(multicast_router_interface_entry
-                            .multicast_replica_instance);
+           << QuotedVar(
+                  multicast_router_interface_entry.multicast_replica_instance);
   }
 
   // Confirm we have a reference to the RIF object ID.
@@ -876,10 +876,11 @@ ReturnCode L3MulticastManager::validateSetMulticastRouterInterfaceEntry(
         router_interface_entry_ptr->action) {
       return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
              << "Multicast router interface entry with key "
-             << QuotedVar(multicast_router_interface_entry.multicast_router_interface_entry_key)
+	     << QuotedVar(multicast_router_interface_entry
+                              .multicast_router_interface_entry_key)
              << " cannot change action from "
-             << QuotedVar(router_interface_entry_ptr->action)
-             << " to " << QuotedVar(multicast_router_interface_entry.action);
+             << QuotedVar(router_interface_entry_ptr->action) << " to "
+             << QuotedVar(multicast_router_interface_entry.action);
     }
 
     if (multicast_router_interface_entry.action == p4orch::kSetMulticastSrcMac) {
@@ -1009,6 +1010,42 @@ ReturnCode L3MulticastManager::processMulticastGroupEntries(
   return status;
 }
 
+ReturnCode L3MulticastManager::createBridgePort(
+    P4MulticastRouterInterfaceEntry& entry, sai_object_id_t* bridge_port_oid) {
+  SWSS_LOG_ENTER();
+
+  Port port;
+  if (!gPortsOrch->getPort(entry.multicast_replica_port, port)) {
+    LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+                         << "Unable to find port object "
+                         << QuotedVar(entry.multicast_replica_port)
+                         << " to create bridge port");
+  }
+
+  std::vector<sai_attribute_t> attrs;
+  sai_attribute_t attr;
+
+  attr.id = SAI_BRIDGE_PORT_ATTR_TYPE;
+  attr.value.s32 = SAI_BRIDGE_PORT_TYPE_PORT;
+  attrs.push_back(attr);
+
+  attr.id = SAI_BRIDGE_PORT_ATTR_PORT_ID;
+  attr.value.oid = port.m_port_id;
+  attrs.push_back(attr);
+
+  sai_status_t status = sai_bridge_api->create_bridge_port(
+      bridge_port_oid, gSwitchId, (uint32_t)attrs.size(), attrs.data());
+
+  if (status != SAI_STATUS_SUCCESS) {
+    LOG_ERROR_AND_RETURN(
+        ReturnCode(status)
+        << "Failed to create bridge port for L2 multicast on port "
+        << QuotedVar(entry.multicast_replica_port));
+  }
+
+  return ReturnCode();
+}
+
 ReturnCode L3MulticastManager::createRouterInterface(
     const std::string& rif_key, P4MulticastRouterInterfaceEntry& entry,
     sai_object_id_t* rif_oid) {
@@ -1136,6 +1173,26 @@ ReturnCode L3MulticastManager::deleteMulticastGroup(
 
 std::vector<ReturnCode> L3MulticastManager::addMulticastRouterInterfaceEntries(
     std::vector<P4MulticastRouterInterfaceEntry>& entries) {
+  SWSS_LOG_ENTER();
+  std::vector<ReturnCode> statuses(entries.size());
+  fillStatusArrayWithNotExecuted(statuses, 0);
+
+  for (size_t i = 0; i < entries.size(); ++i) {
+    auto& entry = entries[i];
+    if (entry.action == p4orch::kSetMulticastSrcMac) {
+      statuses[i] = addL3MulticastRouterInterfaceEntry(entry);
+    } else {
+      statuses[i] = addL2MulticastRouterInterfaceEntry(entry);
+    }
+    if (!statuses[i].ok()) {
+      break;
+    }
+  }
+  return statuses;
+}
+
+ReturnCode L3MulticastManager::addL3MulticastRouterInterfaceEntry(
+    P4MulticastRouterInterfaceEntry& entry) { 
   // There are two cases for add:
   // 1. The new entry (multicast_replica_port, multicast_replica_instance) will
   //    need a new RIF allocated.
@@ -1144,43 +1201,52 @@ std::vector<ReturnCode> L3MulticastManager::addMulticastRouterInterfaceEntries(
   // src mac, and src mac is the action parameter associated with a table entry.
   SWSS_LOG_ENTER();
 
-  std::vector<ReturnCode> statuses(entries.size());
-  fillStatusArrayWithNotExecuted(statuses, 0);
-  for (size_t i = 0; i < entries.size(); ++i) {
-    auto& entry = entries[i];
+  sai_object_id_t rif_oid = getRifOid(&entry);
+  if (rif_oid == SAI_NULL_OBJECT_ID) {
+    std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+        entry.multicast_replica_port, entry.src_mac);
 
-    sai_object_id_t rif_oid = getRifOid(&entry);
-    if (rif_oid == SAI_NULL_OBJECT_ID) {
-      std::string rif_key =
-          KeyGenerator::generateMulticastRouterInterfaceRifKey(
-              entry.multicast_replica_port, entry.src_mac);
+    RETURN_IF_ERROR(createRouterInterface(rif_key, entry, &rif_oid));
 
-      ReturnCode create_status =
-          createRouterInterface(rif_key, entry, &rif_oid);
-      statuses[i] = create_status;
-      if (!create_status.ok()) {
-        break;
-      }
+    gPortsOrch->increasePortRefCount(entry.multicast_replica_port);
+    m_p4OidMapper->setOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key, rif_oid);
+    m_rifOids[rif_key] = rif_oid;
+    m_rifOidToMulticastGroupMembers[rif_oid] = {};
+  }
 
-      gPortsOrch->increasePortRefCount(entry.multicast_replica_port);
-      m_p4OidMapper->setOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key, rif_oid);
-      m_rifOids[rif_key] = rif_oid;
-      m_rifOidToMulticastGroupMembers[rif_oid] = {};
-    }
+  // Operations done regardless of whether RIF was created or not.
+  // Set the entry RIF.
+  entry.router_interface_oid = rif_oid;
 
-    // Operations done regardless of whether RIF was created or not.
-    // Set the entry RIF.
-    entry.router_interface_oid = rif_oid;
+  // Update internal state.
+  m_multicastRouterInterfaceTable[entry.multicast_router_interface_entry_key] =
+      entry;
+  m_rifOidToRouterInterfaceEntries[rif_oid].push_back(entry);
+  return ReturnCode();
+}
 
-    // Update internal state.
-    m_multicastRouterInterfaceTable[entry
-                                        .multicast_router_interface_entry_key] =
-        entry;
-    m_rifOidToRouterInterfaceEntries[rif_oid].push_back(entry);
+ReturnCode L3MulticastManager::addL2MulticastRouterInterfaceEntry(
+    P4MulticastRouterInterfaceEntry& entry) {
+  // There are two cases for add:
+  // 1. The new entry (multicast_replica_port, multicast_replica_instance) will
+  //    need a new bridge port allocated.
+  // 2. The new entry will be able to use an existing bridge port.
+  // Recall that bridge ports depend only on the multicast_replica_port.
+  SWSS_LOG_ENTER();
 
-    statuses[i] = ReturnCode();
-  }  // for i
-  return statuses;
+  sai_object_id_t bridge_port_oid = getBridgePortOid(&entry);
+  if (bridge_port_oid == SAI_NULL_OBJECT_ID) {
+    RETURN_IF_ERROR(createBridgePort(entry, &bridge_port_oid));
+    gPortsOrch->increasePortRefCount(entry.multicast_replica_port);
+    m_p4OidMapper->setOID(SAI_OBJECT_TYPE_BRIDGE_PORT,
+                          entry.multicast_replica_port, bridge_port_oid);
+  }
+
+  // Operations done regardless of whether bridge port was created or not.
+  // Set the entry bridge port.
+  m_multicastRouterInterfaceTable[entry.multicast_router_interface_entry_key] =
+      entry;
+  return ReturnCode();
 }
 
 std::vector<ReturnCode>
@@ -2172,14 +2238,7 @@ std::string L3MulticastManager::verifyMulticastGroupStateCache(
 
 std::string L3MulticastManager::verifyMulticastGroupStateAsicDb(
     const P4MulticastGroupEntry* multicast_group_entry) {
-
   // Confirm group settings.
-  std::vector<sai_attribute_t> group_attrs;  // no required attributes
-  std::vector<swss::FieldValueTuple> exp =
-      saimeta::SaiAttributeList::serialize_attr_list(
-	  SAI_OBJECT_TYPE_IPMC_GROUP, (uint32_t)group_attrs.size(),
-          group_attrs.data(), /*countOnly=*/false);
-
   swss::DBConnector db("ASIC_DB", 0);
   swss::Table table(&db, "ASIC_STATE");
   std::string key =
@@ -2189,12 +2248,9 @@ std::string L3MulticastManager::verifyMulticastGroupStateAsicDb(
   if (!table.get(key, values)) {
     return std::string("ASIC DB key not found ") + key;
   }
-  std::string group_msg =
-      verifyAttrs(values, exp, std::vector<swss::FieldValueTuple>{},
-                  /*allow_unknown=*/false);
-  if (!group_msg.empty()) {
-    return group_msg;
-  }
+  // There are no IPMC group attributes to verify.  The attributes that do
+  // exist are read-only attributes related to how many group members there are.
+  // We check group members and their attributes below.
 
   // Confirm group member settings.
   for (auto& replica : multicast_group_entry->replicas) {
@@ -2217,7 +2273,8 @@ std::string L3MulticastManager::verifyMulticastGroupStateAsicDb(
 
     auto member_attrs = prepareMulticastGroupMemberSaiAttrs(
         multicast_group_entry->multicast_group_oid, rif_oid);
-    exp = saimeta::SaiAttributeList::serialize_attr_list(
+    std::vector<swss::FieldValueTuple> exp =
+        saimeta::SaiAttributeList::serialize_attr_list(
               SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, (uint32_t)member_attrs.size(),
               member_attrs.data(), /*countOnly=*/false);
     key = sai_serialize_object_type(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER) + ":" +
@@ -2268,6 +2325,17 @@ sai_object_id_t L3MulticastManager::getRifOid(
     return SAI_NULL_OBJECT_ID;
   }
   return m_rifOids[rif_key];
+}
+
+// A bridge port is associated with an egress port.
+sai_object_id_t L3MulticastManager::getBridgePortOid(
+    const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
+  sai_object_id_t bridge_port_oid = SAI_NULL_OBJECT_ID;
+  m_p4OidMapper->getOID(
+      SAI_OBJECT_TYPE_BRIDGE_PORT,
+      multicast_router_interface_entry->multicast_replica_port,
+      &bridge_port_oid);
+  return bridge_port_oid;
 }
 
 // A RIF is associated with an egress port and Ethernet src mac value.

--- a/orchagent/p4orch/l3_multicast_manager.h
+++ b/orchagent/p4orch/l3_multicast_manager.h
@@ -190,6 +190,8 @@ class L3MulticastManager : public ObjectManagerInterface {
       const std::string& op, bool update);
 
   // Wrapper around SAI setup and call, for easy mocking.
+  ReturnCode createBridgePort(P4MulticastRouterInterfaceEntry& entry,
+                              sai_object_id_t* bridge_port_oid);
   ReturnCode createRouterInterface(const std::string& rif_key,
                                    P4MulticastRouterInterfaceEntry& entry,
                                    sai_object_id_t* rif_oid);
@@ -211,6 +213,10 @@ class L3MulticastManager : public ObjectManagerInterface {
   // Add new multicast router interface table entries.
   std::vector<ReturnCode> addMulticastRouterInterfaceEntries(
       std::vector<P4MulticastRouterInterfaceEntry>& entries);
+  ReturnCode addL3MulticastRouterInterfaceEntry(
+        P4MulticastRouterInterfaceEntry& entry);
+  ReturnCode addL2MulticastRouterInterfaceEntry(
+        P4MulticastRouterInterfaceEntry& entry);
   // Update existing multicast router interface table entries.
   std::vector<ReturnCode> updateMulticastRouterInterfaceEntries(
       std::vector<P4MulticastRouterInterfaceEntry>& entries);
@@ -281,6 +287,11 @@ class L3MulticastManager : public ObjectManagerInterface {
   // Fetches the RIF OID that will be used by a given multicast replica.
   // This would be the value used by the group member.
   sai_object_id_t getRifOid(const P4Replica& replica);
+
+  // Fetches a bridge port OID for a port that will be used for L2 multicast
+  // group members.
+  sai_object_id_t getBridgePortOid(
+      const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry);
 
   // Internal cache of entries.
   P4MulticastRouterInterfaceTable m_multicastRouterInterfaceTable;

--- a/orchagent/p4orch/next_hop_manager.cpp
+++ b/orchagent/p4orch/next_hop_manager.cpp
@@ -212,7 +212,7 @@ ReturnCodeOr<bool> parseFlag(std::string name, std::string value) {
          << "Invalid " << QuotedVar(name) << " value: " << QuotedVar(value);
 }
 
-std::vector<sai_attribute_t> NextHopManager::getSaiAttrs(
+std::vector<sai_attribute_t> NextHopManager::prepareSaiAttrs(
     const P4NextHopEntry& next_hop_entry) {
   std::vector<sai_attribute_t> next_hop_attrs;
   sai_attribute_t next_hop_attr;
@@ -532,7 +532,7 @@ std::vector<ReturnCode> NextHopManager::createNextHops(
       entries[i].neighbor_id = (*gre_tunnel_or).neighbor_id;
     }
 
-    sai_attrs[i] = getSaiAttrs(entries[i]);
+    sai_attrs[i] = prepareSaiAttrs(entries[i]);
     attrs_cnt[i] = static_cast<uint32_t>(sai_attrs[i].size());
     attrs_ptr[i] = sai_attrs[i].data();
   }
@@ -879,7 +879,7 @@ std::string NextHopManager::verifyStateCache(const P4NextHopAppDbEntry &app_db_e
 
 std::string NextHopManager::verifyStateAsicDb(const P4NextHopEntry *next_hop_entry)
 {
-  std::vector<sai_attribute_t> attrs = getSaiAttrs(*next_hop_entry);
+  std::vector<sai_attribute_t> attrs = prepareSaiAttrs(*next_hop_entry);
   std::vector<swss::FieldValueTuple> exp =
       saimeta::SaiAttributeList::serialize_attr_list(
           SAI_OBJECT_TYPE_NEXT_HOP, (uint32_t)attrs.size(), attrs.data(),

--- a/orchagent/p4orch/next_hop_manager.h
+++ b/orchagent/p4orch/next_hop_manager.h
@@ -109,7 +109,7 @@ class NextHopManager : public ObjectManagerInterface
     std::string verifyStateAsicDb(const P4NextHopEntry *next_hop_entry);
 
     // Returns the SAI attributes for an entry.
-    std::vector<sai_attribute_t> getSaiAttrs(
+    std::vector<sai_attribute_t> prepareSaiAttrs(
         const P4NextHopEntry& next_hop_entry);
 
     // m_nextHopTable: next_hop_key, P4NextHopEntry

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -295,11 +295,11 @@ void P4Orch::handlePortStatusChangeNotification(const std::string &op, const std
 
             if (status == SAI_PORT_OPER_STATUS_UP)
             {
-                m_wcmpManager->restorePrunedNextHops(port.m_alias);
+              m_wcmpManager->updateWatchPort(port.m_alias, false);
             }
             else
             {
-                m_wcmpManager->pruneNextHops(port.m_alias);
+              m_wcmpManager->updateWatchPort(port.m_alias, true);
             }
         }
 

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -376,3 +376,7 @@ GreTunnelManager *P4Orch::getGreTunnelManager()
 TunnelDecapGroupManager* P4Orch::getTunnelDecapGroupManager() {
   return m_tunnelDecapGroupManager.get();
 }
+
+void P4Orch::refreshPortStatus() {
+  m_wcmpManager->refreshPortOperStatus();
+}

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -380,3 +380,7 @@ TunnelDecapGroupManager* P4Orch::getTunnelDecapGroupManager() {
 void P4Orch::refreshPortStatus() {
   m_wcmpManager->refreshPortOperStatus();
 }
+
+void P4Orch::setRouterIntfsMtu(const std::string& port, uint32_t mtu) {
+    m_routerIntfManager->setRouterIntfsMtu(port, mtu);
+}

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -55,6 +55,7 @@ class P4Orch : public Orch
     p4orch::WcmpManager *getWcmpManager();
     GreTunnelManager *getGreTunnelManager();
     TunnelDecapGroupManager* getTunnelDecapGroupManager();
+    void refreshPortStatus();
     TablesInfo *tablesinfo = NULL;
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -56,6 +56,7 @@ class P4Orch : public Orch
     GreTunnelManager *getGreTunnelManager();
     TunnelDecapGroupManager* getTunnelDecapGroupManager();
     void refreshPortStatus();
+    void setRouterIntfsMtu(const std::string& port, uint32_t mtu);
     TablesInfo *tablesinfo = NULL;
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -141,8 +141,7 @@ std::string KeyGenerator::generateRouteKey(const std::string &vrf_id, const swss
 
 std::string KeyGenerator::generateRouterInterfaceKey(const std::string &router_intf_id)
 {
-    std::map<std::string, std::string> fv_map = {{p4orch::kRouterInterfaceId, router_intf_id}};
-    return generateKey(fv_map);
+    return router_intf_id;
 }
 
 std::string KeyGenerator::generateNeighborKey(const std::string &router_intf_id, const swss::IpAddress &neighbor_id)
@@ -154,14 +153,12 @@ std::string KeyGenerator::generateNeighborKey(const std::string &router_intf_id,
 
 std::string KeyGenerator::generateNextHopKey(const std::string &next_hop_id)
 {
-    std::map<std::string, std::string> fv_map = {{p4orch::kNexthopId, next_hop_id}};
-    return generateKey(fv_map);
+    return next_hop_id;
 }
 
 std::string KeyGenerator::generateMirrorSessionKey(const std::string &mirror_session_id)
 {
-    std::map<std::string, std::string> fv_map = {{p4orch::kMirrorSessionId, mirror_session_id}};
-    return generateKey(fv_map);
+    return mirror_session_id;
 }
 
 std::string KeyGenerator::generateMulticastRouterInterfaceKey(
@@ -220,8 +217,7 @@ std::string KeyGenerator::generateIpMulticastKey(
 
 std::string KeyGenerator::generateWcmpGroupKey(const std::string &wcmp_group_id)
 {
-    std::map<std::string, std::string> fv_map = {{p4orch::kWcmpGroupId, wcmp_group_id}};
-    return generateKey(fv_map);
+    return wcmp_group_id;
 }
 
 std::string KeyGenerator::generateAclRuleKey(const std::map<std::string, std::string> &match_fields,
@@ -254,8 +250,7 @@ std::string KeyGenerator::generateL3AdmitKey(const swss::MacAddress &mac_address
 
 std::string KeyGenerator::generateTunnelKey(const std::string &tunnel_id)
 {
-    std::map<std::string, std::string> fv_map = {{p4orch::kTunnelId, tunnel_id}};
-    return generateKey(fv_map);
+    return tunnel_id;
 }
 
 std::string KeyGenerator::generateIpv6TunnelTermKey(

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -56,36 +56,35 @@ ReturnCode validateRouterInterfaceAppDbEntry(const P4RouterInterfaceAppDbEntry &
     return ReturnCode();
 }
 
-ReturnCodeOr<std::vector<sai_attribute_t>> getSaiAttrs(const P4RouterInterfaceEntry &router_intf_entry)
-{
-    Port port;
-    if (!gPortsOrch->getPort(router_intf_entry.port_name, port))
-    {
-        LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-                             << "Failed to get port info for port " << QuotedVar(router_intf_entry.port_name));
-    }
+ReturnCodeOr<std::vector<sai_attribute_t>> prepareSaiAttrs(
+    const P4RouterInterfaceEntry& router_intf_entry) {
+  Port port;
+  if (!gPortsOrch->getPort(router_intf_entry.port_name, port)) {
+    LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+                         << "Failed to get port info for port "
+                         << QuotedVar(router_intf_entry.port_name));
+  }
 
-    std::vector<sai_attribute_t> attrs;
-    sai_attribute_t attr;
+  std::vector<sai_attribute_t> attrs;
+  sai_attribute_t attr;
 
-    // Map all P4 router interfaces to default VRF as virtual router is mandatory
-    // parameter for creation of router interfaces in SAI.
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID;
-    attr.value.oid = gVirtualRouterId;
+  // Map all P4 router interfaces to default VRF as virtual router is mandatory
+  // parameter for creation of router interfaces in SAI.
+  attr.id = SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID;
+  attr.value.oid = gVirtualRouterId;
+  attrs.push_back(attr);
+
+  // If mac address is not set then swss::MacAddress initializes mac address
+  // to 00:00:00:00:00:00.
+  if (router_intf_entry.src_mac_address.to_string() != "00:00:00:00:00:00") {
+    attr.id = SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS;
+    memcpy(attr.value.mac, router_intf_entry.src_mac_address.getMac(),
+           sizeof(sai_mac_t));
     attrs.push_back(attr);
+  }
 
-    // If mac address is not set then swss::MacAddress initializes mac address
-    // to 00:00:00:00:00:00.
-    if (router_intf_entry.src_mac_address.to_string() != "00:00:00:00:00:00")
-    {
-        attr.id = SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS;
-        memcpy(attr.value.mac, router_intf_entry.src_mac_address.getMac(), sizeof(sai_mac_t));
-        attrs.push_back(attr);
-    }
-
-    attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
-    switch (port.m_type)
-    {
+  attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
+  switch (port.m_type) {
     case Port::PHY:
         attr.value.s32 = SAI_ROUTER_INTERFACE_TYPE_PORT;
         attrs.push_back(attr);
@@ -116,7 +115,7 @@ ReturnCodeOr<std::vector<sai_attribute_t>> getSaiAttrs(const P4RouterInterfaceEn
 
     default:
         LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Unsupported port type: " << port.m_type);
-    }
+  }
     attrs.push_back(attr);
 
     // Enable multicast.
@@ -214,7 +213,8 @@ ReturnCode RouterInterfaceManager::createRouterInterface(const std::string &rout
                                                                      << " already exists in the centralized map");
     }
 
-    ASSIGN_OR_RETURN(std::vector<sai_attribute_t> attrs, getSaiAttrs(router_intf_entry));
+    ASSIGN_OR_RETURN(std::vector<sai_attribute_t> attrs,
+                     prepareSaiAttrs(router_intf_entry));
 
     CHECK_ERROR_AND_LOG_AND_RETURN(
         sai_router_intfs_api->create_router_interface(&router_intf_entry.router_interface_oid, gSwitchId,
@@ -559,11 +559,11 @@ std::string RouterInterfaceManager::verifyStateCache(const P4RouterInterfaceAppD
 
 std::string RouterInterfaceManager::verifyStateAsicDb(const P4RouterInterfaceEntry *router_intf_entry)
 {
-    auto attrs_or = getSaiAttrs(*router_intf_entry);
-    if (!attrs_or.ok())
-    {
-        return std::string("Failed to get SAI attrs: ") + attrs_or.status().message();
-    }
+  auto attrs_or = prepareSaiAttrs(*router_intf_entry);
+  if (!attrs_or.ok()) {
+    return std::string("Failed to get SAI attrs: ") +
+           attrs_or.status().message();
+  }
     std::vector<sai_attribute_t> attrs = *attrs_or;
     std::vector<swss::FieldValueTuple> exp = saimeta::SaiAttributeList::serialize_attr_list(
         SAI_OBJECT_TYPE_ROUTER_INTERFACE, (uint32_t)attrs.size(), attrs.data(), /*countOnly=*/false);

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -581,3 +581,29 @@ std::string RouterInterfaceManager::verifyStateAsicDb(const P4RouterInterfaceEnt
     return verifyAttrs(values, exp, std::vector<swss::FieldValueTuple>{},
                        /*allow_unknown=*/false);
 }
+
+void RouterInterfaceManager::setRouterIntfsMtu(const std::string &port, uint32_t mtu)
+{
+    // Update MTU of all router interfaces that are mapped to this port.
+    SWSS_LOG_NOTICE("Update MTU to %u for all router interfaces mapped to port: %s", mtu, port.c_str());
+    for (auto &it : m_routerIntfTable)
+    {
+        if (it.second.port_name != port)
+        {
+            continue;
+        }
+        sai_attribute_t attr;
+        attr.id = SAI_ROUTER_INTERFACE_ATTR_MTU;
+        attr.value.u32 = mtu;
+        sai_status_t status =
+            sai_router_intfs_api->set_router_interface_attribute(it.second.router_interface_oid, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to update MTU for router interface: %s (SAI_STATUS: %s)",
+                           QuotedVar(it.second.router_interface_id).c_str(), sai_serialize_status(status).c_str());
+            continue;
+        }
+        SWSS_LOG_NOTICE("Router interface: %s MTU updated to %u", QuotedVar(it.second.router_interface_id).c_str(),
+                        mtu);
+    }
+}

--- a/orchagent/p4orch/router_interface_manager.h
+++ b/orchagent/p4orch/router_interface_manager.h
@@ -55,6 +55,7 @@ class RouterInterfaceManager : public ObjectManagerInterface
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;
+    void setRouterIntfsMtu(const std::string& port, uint32_t mtu);
 
   private:
     ReturnCodeOr<P4RouterInterfaceAppDbEntry> deserializeRouterIntfEntry(

--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -101,3 +101,5 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 p4orch_tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 p4orch_tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 p4orch_tests_LDADD = $(LDADD_GTEST) $(LDFLAGS_ASAN) -lpthread -lsairedis -lswsscommon -lsaimeta -lsaimetadata -lzmq
+
+LOG_DRIVER = $(top_srcdir)/run-gtest-suite.py

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -1379,11 +1379,6 @@ TEST_F(AclManagerTest, DISABLED_CreatePuntTableFailsWhenUserTrapGroupOrHostifNot
     setUpSwitchOrch();
     // Update p4orch to use new copp orch
     setUpP4Orch();
-    // Fail to create ACL table because the trap group is absent
-    EXPECT_EQ("Trap group was not found given trap group name: " + std::string(GENL_PACKET_TRAP_GROUP_NAME_PREFIX) +
-                  std::to_string(skip_cpu_queue),
-              ProcessAddTableRequest(app_db_entry).message());
-    EXPECT_EQ(nullptr, GetAclTable(app_db_entry.acl_table_name));
 
     // Create the trap group for CPU queue 1 without host interface(genl
     // attributes)

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -26,6 +26,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
       port_stat_manager(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
                         PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, true),
       port_phy_attr_manager(PORT_PHY_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
+      port_phy_serdes_attr_manager(PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
       port_buffer_drop_stat_manager(PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP, StatsMode::READ,
                                     PORT_BUFFER_DROP_STAT_POLLING_INTERVAL_MS, true),
       queue_stat_manager(QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, QUEUE_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -706,6 +706,8 @@ void PortsOrch::doTask(swss::SelectableTimer &timer)
 {
 }
 
+bool PortsOrch::isFrontPanelPort(Port& port) { return true; }
+
 void PortsOrch::onWarmBootEnd()
 {
 }

--- a/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
@@ -12,6 +12,7 @@
 
 #include "ipprefix.h"
 #include "mock_response_publisher.h"
+#include "mock_sai_bridge.h"
 #include "mock_sai_ipmc_group.h"
 #include "mock_sai_router_interface.h"
 #include "p4orch.h"
@@ -40,6 +41,8 @@ extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t gVrfOid;
 extern sai_ipmc_group_api_t* sai_ipmc_group_api;
 extern sai_router_interface_api_t* sai_router_intfs_api;
+extern sai_bridge_api_t* sai_bridge_api;
+
 extern char* gVrfName;
 extern PortsOrch* gPortsOrch;
 extern VRFOrch* gVrfOrch;
@@ -68,6 +71,9 @@ constexpr sai_object_id_t kGroupMemberOid1 = 0x11;
 constexpr sai_object_id_t kGroupMemberOid2 = 0x12;
 constexpr sai_object_id_t kGroupMemberOid3 = 0x13;
 constexpr sai_object_id_t kGroupMemberOid4 = 0x14;
+
+constexpr sai_object_id_t kBridgePortOid1 = 0x101;
+constexpr sai_object_id_t kBridgePortOid2 = 0x102;
 
 // Matches two SAI attributes.
 bool MatchSaiAttribute(const sai_attribute_t& attr,
@@ -164,6 +170,35 @@ class L3MulticastManagerTest : public ::testing::Test {
                   entries[0].multicast_router_interface_entry_key),
               nullptr);
     EXPECT_EQ(GetRifOid(&entries[0]), rif_oid);
+    return entry;
+  }
+
+  P4MulticastRouterInterfaceEntry SetupP4MulticastRouterInterfaceNoActionEntry(
+      const std::string& port, const std::string& instance,
+      const swss::MacAddress mac, const sai_object_id_t bridge_port_oid,
+      bool expect_mock = true) {
+    std::vector<P4MulticastRouterInterfaceEntry> entries;
+    auto entry = GenerateP4MulticastRouterInterfaceEntry(
+        port, instance, mac, /*multicast_metadata=*/"", p4orch::kNoAction);
+    entries.push_back(entry);
+
+    if (expect_mock) {
+      EXPECT_CALL(mock_sai_bridge_, create_bridge_port(_, _, Eq(2), _))
+          .WillOnce(
+              DoAll(SetArgPointee<0>(bridge_port_oid),
+                    Return(SAI_STATUS_SUCCESS)));
+    }
+
+    std::vector<ReturnCode> statuses =
+        AddMulticastRouterInterfaceEntries(entries);
+
+    EXPECT_EQ(statuses.size(), 1);
+    EXPECT_TRUE(statuses[0].ok());
+
+    EXPECT_NE(GetMulticastRouterInterfaceEntry(
+                  entries[0].multicast_router_interface_entry_key),
+              nullptr);
+    EXPECT_EQ(GetBridgePortOid(&entries[0]), bridge_port_oid);
     return entry;
   }
 
@@ -274,6 +309,10 @@ class L3MulticastManagerTest : public ::testing::Test {
         mock_set_ipmc_group_member_attribute;
     sai_ipmc_group_api->get_ipmc_group_member_attribute =
         mock_get_ipmc_group_member_attribute;
+
+    mock_sai_bridge = &mock_sai_bridge_;
+    sai_bridge_api->create_bridge_port = mock_create_bridge_port;
+    sai_bridge_api->remove_bridge_port = mock_remove_bridge_port;
   }
 
   void Enqueue(const std::string& table_name,
@@ -383,6 +422,11 @@ class L3MulticastManagerTest : public ::testing::Test {
     return l3_multicast_manager_.createRouterInterface(rif_key, entry, rif_oid);
   }
 
+  ReturnCode CreateBridgePort(P4MulticastRouterInterfaceEntry& entry,
+                              sai_object_id_t* bridge_port_oid) {
+    return l3_multicast_manager_.createBridgePort(entry, bridge_port_oid);
+  }
+
   ReturnCode DeleteRouterInterface(const std::string& rif_key,
                                    sai_object_id_t rif_oid) {
     return l3_multicast_manager_.deleteRouterInterface(rif_key, rif_oid);
@@ -440,6 +484,12 @@ class L3MulticastManagerTest : public ::testing::Test {
     return l3_multicast_manager_.getRifOid(multicast_router_interface_entry);
   }
 
+  sai_object_id_t GetBridgePortOid(
+      const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
+    return l3_multicast_manager_.getBridgePortOid(
+        multicast_router_interface_entry);
+  }
+
   // Unnatural function to add multicast replication entry reference to a RIF.
   void ForceAddMulticastGroupMember(
       const sai_object_id_t rif_oid,
@@ -465,6 +515,7 @@ class L3MulticastManagerTest : public ::testing::Test {
 
   StrictMock<MockSaiRouterInterface> mock_sai_router_intf_;
   StrictMock<MockSaiIpmcGroup> mock_sai_ipmc_group_;
+  StrictMock<MockSaiBridge> mock_sai_bridge_;
   StrictMock<MockResponsePublisher> publisher_;
   P4OidMapper p4_oid_mapper_;
   L3MulticastManager l3_multicast_manager_;
@@ -846,6 +897,75 @@ TEST_F(L3MulticastManagerTest,
   // First entry fails, second should not be executed.
   EXPECT_EQ(statuses[0].code(), StatusCode::SWSS_RC_UNKNOWN);
   EXPECT_EQ(statuses[1].code(), StatusCode::SWSS_RC_NOT_EXECUTED);
+}
+
+TEST_F(L3MulticastManagerTest,
+       AddMulticastRouterInterfaceEntryNoActionSuccess) {
+  auto entry = SetupP4MulticastRouterInterfaceNoActionEntry(
+      "Ethernet1", /*instance=*/"0x0", swss::MacAddress(kSrcMac1),
+      kBridgePortOid1);
+  EXPECT_EQ(kBridgePortOid1, GetBridgePortOid(&entry));
+}
+
+TEST_F(L3MulticastManagerTest,
+       AddMulticastRouterInterfaceEntryNoActionSaiFailure) {
+  std::vector<P4MulticastRouterInterfaceEntry> entries;
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet1", /*instance=*/"0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  auto entry2 = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", /*instance=*/"0x0", swss::MacAddress(kSrcMac2),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  entries.push_back(entry);
+  entries.push_back(entry2);
+
+  EXPECT_CALL(mock_sai_bridge_, create_bridge_port(_, _, Eq(2), _))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+
+  std::vector<ReturnCode> statuses =
+      AddMulticastRouterInterfaceEntries(entries);
+
+  EXPECT_EQ(statuses.size(), 2);
+  EXPECT_EQ(statuses[0].code(), StatusCode::SWSS_RC_UNKNOWN);
+  EXPECT_EQ(statuses[1].code(), StatusCode::SWSS_RC_NOT_EXECUTED);
+
+  EXPECT_EQ(GetMulticastRouterInterfaceEntry(
+                entries[0].multicast_router_interface_entry_key),
+            nullptr);
+  EXPECT_EQ(GetMulticastRouterInterfaceEntry(
+                entries[1].multicast_router_interface_entry_key),
+            nullptr);
+  EXPECT_EQ(GetBridgePortOid(&entries[0]), SAI_NULL_OBJECT_ID);
+  EXPECT_EQ(GetBridgePortOid(&entries[1]), SAI_NULL_OBJECT_ID);
+}
+
+TEST_F(L3MulticastManagerTest,
+       AddMulticastRouterInterfaceEntryNoActionInvalidPortFailure) {
+  std::vector<P4MulticastRouterInterfaceEntry> entries;
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "InvalidPort", /*instance=*/"0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  auto entry2 = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", /*instance=*/"0x0", swss::MacAddress(kSrcMac2),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  entries.push_back(entry);
+  entries.push_back(entry2);
+
+  std::vector<ReturnCode> statuses =
+      AddMulticastRouterInterfaceEntries(entries);
+
+  EXPECT_EQ(statuses.size(), 2);
+  EXPECT_EQ(statuses[0].code(), StatusCode::SWSS_RC_NOT_FOUND);
+  EXPECT_EQ(statuses[1].code(), StatusCode::SWSS_RC_NOT_EXECUTED);
+
+  EXPECT_EQ(GetMulticastRouterInterfaceEntry(
+                entries[0].multicast_router_interface_entry_key),
+            nullptr);
+  EXPECT_EQ(GetMulticastRouterInterfaceEntry(
+                entries[1].multicast_router_interface_entry_key),
+            nullptr);
+  EXPECT_EQ(GetBridgePortOid(&entries[0]), SAI_NULL_OBJECT_ID);
+  EXPECT_EQ(GetBridgePortOid(&entries[1]), SAI_NULL_OBJECT_ID);
 }
 
 TEST_F(L3MulticastManagerTest, DeleteMulticastRouterInterfaceEntriesSuccess) {
@@ -4593,20 +4713,7 @@ TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupMissingAsicDb) {
   // No key should also fail.
   EXPECT_FALSE(VerifyState(db_key, attributes).empty());
 
-  // Reset group member, add extra attribute for group.
-  table.set("SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1",
-            std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
-                "SAI_IPMC_SOMETHING_EXTRA", "oid:0x123456"}});
-  table.set(
-      "SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER:oid:0x11",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID",
-                                "oid:0x1"},
-          swss::FieldValueTuple{"SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID",
-                                "oid:0x123456"}});
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
   table.del("SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1");
-  table.del("SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER:oid:0x11");
 }
 
 TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupAsicDbNoRif) {

--- a/orchagent/p4orch/tests/mock_sai_next_hop_group.h
+++ b/orchagent/p4orch/tests/mock_sai_next_hop_group.h
@@ -6,7 +6,6 @@
 extern "C"
 {
 #include "sai.h"
-#include "sainexthopgroup.h"
 }
 
 // Mock class including mock functions mapping to SAI next hop group's
@@ -56,7 +55,8 @@ class MockSaiNextHopGroup
     MOCK_METHOD1(remove_next_hop_group_member, sai_status_t(_In_ sai_object_id_t next_hop_group_member_id));
 
     MOCK_METHOD2(set_next_hop_group_member_attribute,
-                 sai_status_t(_In_ sai_object_id_t next_hop_group_member_id, _In_ const sai_attribute_t *attr));
+                 sai_status_t(_In_ sai_object_id_t next_hop_group_member_id,
+                              _In_ const sai_attribute_t* attr));
 
     MOCK_METHOD7(create_next_hop_groups,
                sai_status_t(_In_ sai_object_id_t switch_id,
@@ -82,6 +82,13 @@ class MockSaiNextHopGroup
     MOCK_METHOD4(remove_next_hop_group_members,
                  sai_status_t(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id,
                               _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses));
+
+    MOCK_METHOD5(set_next_hop_groups_attribute,
+                 sai_status_t(_In_ uint32_t object_count,
+                              _In_ const sai_object_id_t* object_id,
+                              _In_ const sai_attribute_t* attr_list,
+                              _In_ sai_bulk_op_error_mode_t mode,
+                              _Out_ sai_status_t* object_statuses));
 
     MOCK_METHOD6(get_next_hop_groups_attribute,
                sai_status_t(_In_ uint32_t object_count,
@@ -179,6 +186,14 @@ sai_status_t mock_get_neighbor_entries_attribute(
     _In_ uint32_t object_count, _In_ const sai_neighbor_entry_t* neighbor_entry,
     _In_ const uint32_t* attr_count, _Inout_ sai_attribute_t** attr_list,
     _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t* object_statuses);
+
+sai_status_t set_next_hop_groups_attribute(
+    _In_ uint32_t object_count, _In_ const sai_object_id_t* object_id,
+    _In_ const sai_attribute_t* attr_list, _In_ sai_bulk_op_error_mode_t mode,
+    _Out_ sai_status_t* object_statuses) {
+  return mock_sai_next_hop_group->set_next_hop_groups_attribute(
+      object_count, object_id, attr_list, mode, object_statuses);
+}
 
 sai_status_t get_next_hop_groups_attribute(
     _In_ uint32_t object_count, _In_ const sai_object_id_t* object_id,

--- a/orchagent/p4orch/tests/p4orch_util_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_util_test.cpp
@@ -14,13 +14,13 @@ namespace
 TEST(P4OrchUtilTest, KeyGeneratorTest)
 {
     std::string intf_key = KeyGenerator::generateRouterInterfaceKey("intf-qe-3/7");
-    EXPECT_EQ("router_interface_id=intf-qe-3/7", intf_key);
+    EXPECT_EQ("intf-qe-3/7", intf_key);
     std::string neighbor_key = KeyGenerator::generateNeighborKey("intf-qe-3/7", swss::IpAddress("10.0.0.22"));
     EXPECT_EQ("neighbor_id=10.0.0.22:router_interface_id=intf-qe-3/7", neighbor_key);
     std::string nexthop_key = KeyGenerator::generateNextHopKey("ju1u32m1.atl11:qe-3/7");
-    EXPECT_EQ("nexthop_id=ju1u32m1.atl11:qe-3/7", nexthop_key);
+    EXPECT_EQ("ju1u32m1.atl11:qe-3/7", nexthop_key);
     std::string wcmp_group_key = KeyGenerator::generateWcmpGroupKey("group-1");
-    EXPECT_EQ("wcmp_group_id=group-1", wcmp_group_key);
+    EXPECT_EQ("group-1", wcmp_group_key);
     std::string ipv4_route_key = KeyGenerator::generateRouteKey("b4-traffic", swss::IpPrefix("10.11.12.0/24"));
     EXPECT_EQ("ipv4_dst=10.11.12.0/24:vrf_id=b4-traffic", ipv4_route_key);
     ipv4_route_key = KeyGenerator::generateRouteKey("b4-traffic", swss::IpPrefix("0.0.0.0/0"));

--- a/orchagent/p4orch/tests/router_interface_manager_test.cpp
+++ b/orchagent/p4orch/tests/router_interface_manager_test.cpp
@@ -271,6 +271,11 @@ class RouterInterfaceManagerTest : public ::testing::Test
         return router_intf_manager_.getRouterInterfaceEntry(router_intf_key);
     }
 
+    void SetRouterIntfsMtu(const std::string& port, uint32_t mtu) {
+    	router_intf_manager_.setRouterIntfsMtu(port, mtu);
+    }
+
+
     void ValidateRouterInterfaceEntry(const P4RouterInterfaceEntry &expected_entry)
     {
         const std::string router_intf_key =
@@ -1147,4 +1152,34 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateAsicDbTest)
     router_intf_entry_ptr->port_name = "Ethernet8";
     EXPECT_FALSE(VerifyState(db_key, attributes).empty());
     router_intf_entry_ptr->port_name = "Ethernet7";
+}
+
+TEST_F(RouterInterfaceManagerTest, UpdateRifMtuWhenPortMtuChanges)
+{
+    // Create 2 router interfaces on different ports.
+    P4RouterInterfaceEntry router_intf_entry1(kRouterInterfaceId1, kPortName1, kMacAddress1);
+    router_intf_entry1.router_interface_oid = kRouterInterfaceOid1;
+    AddRouterInterfaceEntry(router_intf_entry1, kPortOid1, kMtu1);
+    P4RouterInterfaceEntry router_intf_entry2(kRouterInterfaceId2, kPortName2, kMacAddress2);
+    router_intf_entry2.router_interface_oid = kRouterInterfaceOid2;
+    AddRouterInterfaceEntry(router_intf_entry2, kPortOid2, kMtu2);
+    // Update MTU on first router interface.
+    sai_attribute_value_t attr_value;
+    attr_value.u32 = kMtu2;
+    std::unordered_map<sai_attr_id_t, sai_attribute_value_t> attr_list = {{SAI_ROUTER_INTERFACE_ATTR_MTU, attr_value}};
+    EXPECT_CALL(mock_sai_router_intf_,
+                set_router_interface_attribute(
+                    Eq(router_intf_entry1.router_interface_oid),
+                    Truly(std::bind(MatchCreateRouterInterfaceAttributeList, std::placeholders::_1, attr_list))))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    SetRouterIntfsMtu(kPortName1, kMtu2);
+    // Update MTU on second router interface which encounters a SAI failure.
+    attr_value.u32 = kMtu1;
+    attr_list[SAI_ROUTER_INTERFACE_ATTR_MTU] = attr_value;
+    EXPECT_CALL(mock_sai_router_intf_,
+                set_router_interface_attribute(
+                    Eq(router_intf_entry2.router_interface_oid),
+                    Truly(std::bind(MatchCreateRouterInterfaceAttributeList, std::placeholders::_1, attr_list))))
+        .WillOnce(Return(SAI_STATUS_FAILURE));
+    SetRouterIntfsMtu(kPortName2, kMtu1);
 }

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -1136,6 +1136,24 @@ TEST_F(WcmpManagerTest, ValidateWcmpGroupEntryWithInvalidWatchportAttributeFails
     EXPECT_EQ(0, ref_cnt);
 }
 
+TEST_F(WcmpManagerTest, CreateWcmpGroupFailsWithNonFrontPanelPortAsWatchport)
+{
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
+    P4WcmpGroupEntry app_db_entry = getDefaultWcmpGroupEntryForTest();
+    app_db_entry.wcmp_group_members[0]->watch_port = "PortChannel001";
+
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+              ProcessAddRequest(&app_db_entry));
+    std::string key = KeyGenerator::generateWcmpGroupKey(kWcmpGroupId1);
+    auto* wcmp_group_entry_ptr = GetWcmpGroupEntry(kWcmpGroupId1);
+    EXPECT_EQ(nullptr, wcmp_group_entry_ptr);
+    EXPECT_FALSE(p4_oid_mapper_->existsOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                            kNexthopKey1, &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
 TEST_F(WcmpManagerTest, PruneNextHopSucceeds)
 {
     // Add member with operationally up watch port
@@ -1721,23 +1739,27 @@ TEST_F(WcmpManagerTest, WatchportStateChangeToOperUpSucceeds)
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
-TEST_F(WcmpManagerTest, WatchportStateChangeFromOperUnknownToDownPrunesMemberOnlyOnceSuceeds)
+TEST_F(WcmpManagerTest,
+       WatchportStateChangeFromOperUnknownToDownPrunesMemberOnlyOnceSucceeds)
 {
     // Add member with operationally unknown watch port. Since associated
     // watchport is not operationally up, member will not be created in SAI but
     // will be directly added to the pruned set of WCMP group members.
     std::string port_name = "Ethernet1";
     P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
+    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
+                                               true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 
     // Send port down signal.
     // Verify that the pruned next hop member is not pruned again.
     std::string op = "port_state_change";
-    std::string data = "[{\"port_id\":\"oid:0x56789abcfff\",\"port_state\":\"SAI_PORT_OPER_"
-                       "STATUS_DOWN\",\"port_error_status\":\"0\"}]";
+    std::string data =
+        "[{\"port_id\":\"oid:0x56789abcfff\",\"port_state\":\"SAI_PORT_OPER_"
+        "STATUS_DOWN\",\"port_error_status\":\"0\"}]";
     HandlePortStatusChangeNotification(op, data);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
+    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
+                                               true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -59,140 +59,65 @@ constexpr char* kWcmpGroupId3 = "group-3";
 constexpr sai_object_id_t kWcmpGroupOid1 = 10;
 constexpr char *kNexthopId1 = "ju1u32m1.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid1 = 1;
-constexpr sai_object_id_t kWcmpGroupMemberOid1 = 11;
 constexpr char *kNexthopId2 = "ju1u32m2.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid2 = 2;
-constexpr sai_object_id_t kWcmpGroupMemberOid2 = 12;
 constexpr char *kNexthopId3 = "ju1u32m3.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid3 = 3;
-constexpr sai_object_id_t kWcmpGroupMemberOid3 = 13;
-constexpr sai_object_id_t kWcmpGroupMemberOid4 = 14;
-constexpr sai_object_id_t kWcmpGroupMemberOid5 = 15;
 const std::string kWcmpGroupKey1 = KeyGenerator::generateWcmpGroupKey(kWcmpGroupId1);
 const std::string kNexthopKey1 = KeyGenerator::generateNextHopKey(kNexthopId1);
 const std::string kNexthopKey2 = KeyGenerator::generateNextHopKey(kNexthopId2);
 const std::string kNexthopKey3 = KeyGenerator::generateNextHopKey(kNexthopId3);
 
-// Matches two SAI attributes.
-bool MatchSaiAttribute(const sai_attribute_t &attr, const sai_attribute_t &exp_attr)
-{
-    if (exp_attr.id == SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID)
-    {
-        if (attr.id != SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID || attr.value.oid != exp_attr.value.oid)
-        {
-            return false;
-        }
+MATCHER_P(ArrayEq, array, "") {
+  for (size_t i = 0; i < array.size(); ++i) {
+    if (arg[i] != array[i]) {
+      return false;
     }
-    if (exp_attr.id == SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID)
-    {
-        if (attr.id != SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID || attr.value.oid != exp_attr.value.oid)
-        {
-            return false;
-        }
-    }
-    if (exp_attr.id == SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT)
-    {
-        if (attr.id != SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT || attr.value.u32 != exp_attr.value.u32)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-MATCHER_P(ArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        if (arg[i] != array[i])
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-MATCHER_P(AttrArrayArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        for (size_t j = 0; j < array[i].size(); j++)
-        {
-            if (!MatchSaiAttribute(arg[i][j], array[i][j]))
-            {
-                return false;
-            }
-        }
-    }
-    return true;
+  }
+  return true;
 }
 
 // Matches the next hop group type sai_attribute_t argument.
-bool MatchSaiNextHopGroupAttribute(const sai_attribute_t *attr)
-{
-    if (attr == nullptr || attr->id != SAI_NEXT_HOP_GROUP_ATTR_TYPE || attr->value.s32 != SAI_NEXT_HOP_GROUP_TYPE_ECMP)
-    {
-        return false;
+bool MatchSaiNextHopGroupAttribute(const sai_attribute_t* attr,
+                                   const P4WcmpGroupEntry& entry, bool update) {
+  if (attr == nullptr) {
+    return false;
+  }
+  int attr_size = 2;
+  if (!update) {
+    attr_size = 3;
+    if (attr[0].id != SAI_NEXT_HOP_GROUP_ATTR_TYPE ||
+        attr[0].value.s32 != SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS) {
+      return false;
     }
-    return true;
-}
+  }
+  if (attr[attr_size - 2].id != SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST ||
+      attr[attr_size - 1].id !=
+          SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST) {
+    return false;
+  }
 
-// Matches the action type sai_attribute_t argument.
-bool MatchSaiNextHopGroupMemberAttribute(const sai_object_id_t expected_next_hop_oid, const int expected_weight,
-                                         const sai_object_id_t expected_wcmp_group_oid,
-                                         const sai_attribute_t *attr_list)
-{
-    if (attr_list == nullptr)
-    {
-        return false;
+  uint32_t count = 0;
+  std::vector<sai_object_id_t> nexthop_ids;
+  std::vector<uint32_t> nexthop_weights;
+  for (const auto& member : entry.wcmp_group_members) {
+    if (!member->pruned) {
+      nexthop_ids.push_back(member->next_hop_oid);
+      nexthop_weights.push_back(member->weight);
+      count++;
     }
-    for (int i = 0; i < 3; ++i)
-    {
-        switch (attr_list[i].id)
-        {
-        case SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID:
-            if (attr_list[i].value.oid != expected_wcmp_group_oid)
-            {
-                return false;
-            }
-            break;
-        case SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID:
-            if (attr_list[i].value.oid != expected_next_hop_oid)
-            {
-                return false;
-            }
-            break;
-        case SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT:
-            if (attr_list[i].value.u32 != (uint32_t)expected_weight)
-            {
-                return false;
-            }
-            break;
-        default:
-            break;
-        }
+  }
+  if (attr[attr_size - 2].value.objlist.count != count ||
+      attr[attr_size - 1].value.u32list.count != count) {
+    return false;
+  }
+  for (uint32_t i = 0; i < count; ++i) {
+    if (attr[attr_size - 2].value.objlist.list[i] != nexthop_ids[i] ||
+        attr[attr_size - 1].value.u32list.list[i] != nexthop_weights[i]) {
+      return false;
     }
-    return true;
-}
-
-std::vector<sai_attribute_t> GetSaiNextHopGroupMemberAttribute(sai_object_id_t next_hop_oid, uint32_t weight,
-                                                               sai_object_id_t group_oid)
-{
-    std::vector<sai_attribute_t> attrs;
-    sai_attribute_t attr;
-    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID;
-    attr.value.oid = group_oid;
-    attrs.push_back(attr);
-
-    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID;
-    attr.value.oid = next_hop_oid;
-    attrs.push_back(attr);
-
-    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT;
-    attr.value.u32 = weight;
-    attrs.push_back(attr);
-
-    return attrs;
+  }
+  return true;
 }
 
 void VerifyWcmpGroupMemberEntry(const std::string &expected_next_hop_id, const int expected_weight,
@@ -247,11 +172,8 @@ class WcmpManagerTest : public ::testing::Test
 
         sai_next_hop_group_api->create_next_hop_group = create_next_hop_group;
         sai_next_hop_group_api->remove_next_hop_group = remove_next_hop_group;
-        sai_next_hop_group_api->create_next_hop_group_member = create_next_hop_group_member;
-        sai_next_hop_group_api->remove_next_hop_group_member = remove_next_hop_group_member;
-        sai_next_hop_group_api->set_next_hop_group_member_attribute = set_next_hop_group_member_attribute;
-        sai_next_hop_group_api->create_next_hop_group_members = create_next_hop_group_members;
-        sai_next_hop_group_api->remove_next_hop_group_members = remove_next_hop_group_members;
+        sai_next_hop_group_api->set_next_hop_groups_attribute =
+            set_next_hop_groups_attribute;
 
         sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
         sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
@@ -304,12 +226,12 @@ class WcmpManagerTest : public ::testing::Test
 
     void PruneNextHops(const std::string &port)
     {
-        wcmp_group_manager_->pruneNextHops(port);
+      wcmp_group_manager_->updateWatchPort(port, true);
     }
 
     void RestorePrunedNextHops(const std::string &port)
     {
-        wcmp_group_manager_->restorePrunedNextHops(port);
+      wcmp_group_manager_->updateWatchPort(port, false);
     }
 
     bool VerifyWcmpGroupMemberInPortMap(std::shared_ptr<P4WcmpGroupMemberEntry> gm, bool expected_member_present,
@@ -401,27 +323,19 @@ P4WcmpGroupEntry WcmpManagerTest::AddWcmpGroupEntryWithWatchport(const std::stri
     gm1->weight = 2;
     gm1->watch_port = port;
     gm1->wcmp_group_id = kWcmpGroupId1;
+    if (!oper_up) {
+      gm1->pruned = true;
+    }
     app_db_entry.wcmp_group_members.push_back(gm1);
     p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group(_, Eq(gSwitchId), Eq(1),
-                                      Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    // For members with non empty watchport field, member creation in SAI happens
-    // for operationally up ports only..
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1};
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    if (oper_up)
-    {
-        EXPECT_CALL(
-            mock_sai_next_hop_group_,
-            create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                          AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                              GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1)}),
-                                          Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-            .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                            SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    }
+    EXPECT_CALL(
+        mock_sai_next_hop_group_,
+        create_next_hop_group(_, Eq(gSwitchId), Eq(3),
+                              Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                              std::placeholders::_1,
+                                              app_db_entry, /*update=*/false))))
+        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1),
+                        Return(SAI_STATUS_SUCCESS)));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddRequest(&app_db_entry));
     EXPECT_NE(nullptr, GetWcmpGroupEntry(kWcmpGroupId1));
     return app_db_entry;
@@ -432,21 +346,16 @@ P4WcmpGroupEntry WcmpManagerTest::AddWcmpGroupEntry1()
     P4WcmpGroupEntry app_db_entry = getDefaultWcmpGroupEntryForTest();
     p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
     p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, kNexthopOid3);
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group(_, Eq(gSwitchId), Eq(1),
-                                      Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, kWcmpGroupMemberOid2};
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3,
+                           kNexthopOid3);
+    EXPECT_CALL(
+        mock_sai_next_hop_group_,
+        create_next_hop_group(_, Eq(gSwitchId), Eq(3),
+                              Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                              std::placeholders::_1,
+                                              app_db_entry, /*update=*/false))))
+        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1),
+                        Return(SAI_STATUS_SUCCESS)));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddRequest(&app_db_entry));
     EXPECT_NE(nullptr, GetWcmpGroupEntry(kWcmpGroupId1));
     return app_db_entry;
@@ -480,115 +389,15 @@ std::shared_ptr<P4WcmpGroupMemberEntry> WcmpManagerTest::createWcmpGroupMemberEn
 TEST_F(WcmpManagerTest, CreateWcmpGroup)
 {
     AddWcmpGroupEntry1();
-    P4WcmpGroupEntry expect_entry = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
+    P4WcmpGroupEntry expect_entry = {.wcmp_group_id = kWcmpGroupId1,
+                                     .wcmp_group_members = {},
+                                     .nexthop_ids = {},
+                                     .nexthop_weights = {}};
     std::shared_ptr<P4WcmpGroupMemberEntry> gm_entry1 = createWcmpGroupMemberEntry(kNexthopId1, 2);
     expect_entry.wcmp_group_members.push_back(gm_entry1);
     std::shared_ptr<P4WcmpGroupMemberEntry> gm_entry2 = createWcmpGroupMemberEntry(kNexthopId2, 1);
     expect_entry.wcmp_group_members.push_back(gm_entry2);
     VerifyWcmpGroupEntry(expect_entry, *GetWcmpGroupEntry(kWcmpGroupId1));
-}
-
-TEST_F(WcmpManagerTest, CreateWcmpGroupFailsWhenCreateGroupMemberSaiCallFails)
-{
-    P4WcmpGroupEntry app_db_entry = getDefaultWcmpGroupEntryForTest();
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
-    // WCMP group creation fails when one of the group member creation fails
-    EXPECT_CALL(mock_sai_next_hop_group_, create_next_hop_group(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS, SAI_STATUS_ITEM_NOT_FOUND};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_ITEM_NOT_FOUND)));
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, ProcessAddRequest(&app_db_entry));
-    std::string key = KeyGenerator::generateWcmpGroupKey(kWcmpGroupId1);
-    auto *wcmp_group_entry_ptr = GetWcmpGroupEntry(kWcmpGroupId1);
-    EXPECT_EQ(nullptr, wcmp_group_entry_ptr);
-    EXPECT_FALSE(p4_oid_mapper_->existsOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(WcmpManagerTest, CreateWcmpGroupFailsWhenCreateGroupMemberSaiCallFailsPlusGroupMemberRecoveryFails)
-{
-    P4WcmpGroupEntry app_db_entry = getDefaultWcmpGroupEntryForTest();
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
-    // WCMP group creation fails when one of the group member creation fails
-    EXPECT_CALL(mock_sai_next_hop_group_, create_next_hop_group(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS, SAI_STATUS_ITEM_NOT_FOUND};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_ITEM_NOT_FOUND)));
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_FAILURE)));
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
-
-    // TODO: Expect critical state.
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, ProcessAddRequest(&app_db_entry));
-}
-
-TEST_F(WcmpManagerTest, CreateWcmpGroupFailsWhenCreateGroupMemberSaiCallFailsPlusGroupRecoveryFails)
-{
-    P4WcmpGroupEntry app_db_entry = getDefaultWcmpGroupEntryForTest();
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
-    // WCMP group creation fails when one of the group member creation fails
-    EXPECT_CALL(mock_sai_next_hop_group_, create_next_hop_group(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS, SAI_STATUS_ITEM_NOT_FOUND};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_ITEM_NOT_FOUND)));
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
-        .WillOnce(Return(SAI_STATUS_FAILURE));
-
-    // TODO: Expect critical state.
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, ProcessAddRequest(&app_db_entry));
 }
 
 TEST_F(WcmpManagerTest, CreateWcmpGroupFailsWhenCreateGroupSaiCallFails)
@@ -624,694 +433,230 @@ TEST_F(WcmpManagerTest, RemoveWcmpGroupFailsWhenNotExist)
 
 TEST_F(WcmpManagerTest, RemoveWcmpGroupFailsWhenSaiCallFails)
 {
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntry1();
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2, kWcmpGroupMemberOid1}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
-        .WillOnce(Return(SAI_STATUS_FAILURE));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, kWcmpGroupMemberOid2};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, RemoveWcmpGroup(kWcmpGroupId1));
-}
-
-TEST_F(WcmpManagerTest, RemoveWcmpGroupFailsWhenMemberRemovalFails)
-{
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntry1();
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2, kWcmpGroupMemberOid1}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_FAILURE)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, RemoveWcmpGroup(kWcmpGroupId1));
-}
-
-TEST_F(WcmpManagerTest, RemoveWcmpGroupFailsWhenMemberRemovalFailsPlusRecoveryFails)
-{
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntry1();
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2, kWcmpGroupMemberOid1}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_FAILURE)));
-    std::vector<sai_object_id_t> return_oids{SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, RemoveWcmpGroup(kWcmpGroupId1));
+  P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntry1();
+  EXPECT_CALL(mock_sai_next_hop_group_,
+              remove_next_hop_group(Eq(kWcmpGroupOid1)))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+  EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, RemoveWcmpGroup(kWcmpGroupId1));
 }
 
 TEST_F(WcmpManagerTest, UpdateWcmpGroupMembersSucceed)
 {
-    AddWcmpGroupEntry1();
-    // Update WCMP group member with nexthop_id=kNexthopId1 weight to 3,
-    // nexthop_id=kNexthopId2 weight to 15.
-    P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm1 = createWcmpGroupMemberEntry(kNexthopId1, 3);
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm2 = createWcmpGroupMemberEntry(kNexthopId2, 15);
-    wcmp_group.wcmp_group_members.push_back(gm1);
-    wcmp_group.wcmp_group_members.push_back(gm2);
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_4{kWcmpGroupMemberOid4};
-    std::vector<sai_object_id_t> return_oids_5{kWcmpGroupMemberOid5};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 3, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_4.begin(), return_oids_4.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 15, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_5.begin(), return_oids_5.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
-    VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    uint32_t wcmp_group_refcount = 0;
-    uint32_t nexthop_refcount = 0;
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(2, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    // Remove group member with nexthop_id=kNexthopId1
-    wcmp_group.wcmp_group_members.clear();
-    gm2 = createWcmpGroupMemberEntry(kNexthopId2, 15);
-    wcmp_group.wcmp_group_members.push_back(gm2);
-    exp_remove_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid4}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid5}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_2{kWcmpGroupMemberOid2};
-    exp_create_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 15, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_2.begin(), return_oids_2.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
-    VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(1, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    // Add group member with nexthop_id=kNexthopId1 and weight=20
-    wcmp_group.wcmp_group_members.clear();
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm2 = createWcmpGroupMemberEntry(kNexthopId2, 15);
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm1 = createWcmpGroupMemberEntry(kNexthopId1, 20);
-    wcmp_group.wcmp_group_members.push_back(updated_gm1);
-    wcmp_group.wcmp_group_members.push_back(updated_gm2);
-    exp_remove_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_1{kWcmpGroupMemberOid1};
-    exp_create_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 20, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_1.begin(), return_oids_1.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 15, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_5.begin(), return_oids_5.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
-    VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(2, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
+  AddWcmpGroupEntry1();
+  // Update WCMP group member with nexthop_id=kNexthopId1 weight to 3,
+  // nexthop_id=kNexthopId2 weight to 15.
+  P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1,
+                                 .wcmp_group_members = {},
+                                 .nexthop_ids = {},
+                                 .nexthop_weights = {}};
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm1 =
+      createWcmpGroupMemberEntry(kNexthopId1, 3);
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm2 =
+      createWcmpGroupMemberEntry(kNexthopId2, 15);
+  wcmp_group.wcmp_group_members.push_back(gm1);
+  wcmp_group.wcmp_group_members.push_back(gm2);
 
-    // Update WCMP without group members
-    wcmp_group.wcmp_group_members.clear();
-    exp_remove_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid5}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
-    VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(0, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          wcmp_group, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
+  VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
+  uint32_t wcmp_group_refcount = 0;
+  uint32_t nexthop_refcount = 0;
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
+  EXPECT_EQ(0, wcmp_group_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey1, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey2, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  // Remove group member with nexthop_id=kNexthopId1
+  wcmp_group.wcmp_group_members.clear();
+  gm2 = createWcmpGroupMemberEntry(kNexthopId2, 15);
+  wcmp_group.wcmp_group_members.push_back(gm2);
+
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          wcmp_group, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
+  VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
+  EXPECT_EQ(0, wcmp_group_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey1, &nexthop_refcount));
+  EXPECT_EQ(0, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey2, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  // Add group member with nexthop_id=kNexthopId1 and weight=20
+  wcmp_group.wcmp_group_members.clear();
+  std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm2 =
+      createWcmpGroupMemberEntry(kNexthopId2, 15);
+  std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm1 =
+      createWcmpGroupMemberEntry(kNexthopId1, 20);
+  wcmp_group.wcmp_group_members.push_back(updated_gm1);
+  wcmp_group.wcmp_group_members.push_back(updated_gm2);
+
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          wcmp_group, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
+  VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
+  EXPECT_EQ(0, wcmp_group_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey1, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey2, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+
+  // Update WCMP without group members
+  wcmp_group.wcmp_group_members.clear();
+
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          wcmp_group, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
+  VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
+  EXPECT_EQ(0, wcmp_group_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey1, &nexthop_refcount));
+  EXPECT_EQ(0, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey2, &nexthop_refcount));
+  EXPECT_EQ(0, nexthop_refcount);
 }
 
-TEST_F(WcmpManagerTest, UpdateWcmpGroupFailsWhenRemoveGroupMemberSaiCallFails)
-{
-    AddWcmpGroupEntry1();
-    // Add WCMP group member with nexthop_id=kNexthopId1, weight=3 and
-    // nexthop_id=kNexthopId3, weight=30, update nexthop_id=kNexthopId2
-    // weight to 10.
-    P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm1 = createWcmpGroupMemberEntry(kNexthopId1, 3);
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm2 = createWcmpGroupMemberEntry(kNexthopId2, 10);
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm3 = createWcmpGroupMemberEntry(kNexthopId3, 30);
+TEST_F(WcmpManagerTest, UpdateWcmpGroupFailsWhenSaiCallFails) {
+  AddWcmpGroupEntry1();
+  // Add WCMP group member with nexthop_id=kNexthopId1, weight=3 and
+  // nexthop_id=kNexthopId3, weight=30, update nexthop_id=kNexthopId2
+  // weight to 10.
+  P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1,
+                                 .wcmp_group_members = {},
+                                 .nexthop_ids = {},
+                                 .nexthop_weights = {}};
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm1 =
+      createWcmpGroupMemberEntry(kNexthopId1, 3);
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm2 =
+      createWcmpGroupMemberEntry(kNexthopId2, 10);
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm3 =
+      createWcmpGroupMemberEntry(kNexthopId3, 30);
 
-    wcmp_group.wcmp_group_members.push_back(gm1);
-    wcmp_group.wcmp_group_members.push_back(gm2);
-    wcmp_group.wcmp_group_members.push_back(gm3);
-    std::vector<sai_object_id_t> return_oids_4{kWcmpGroupMemberOid4};
-    std::vector<sai_object_id_t> return_oids_5_6{kWcmpGroupMemberOid5, kWcmpGroupMemberOid3};
-    std::vector<sai_status_t> exp_create_status_1{SAI_STATUS_SUCCESS};
-    std::vector<sai_status_t> exp_create_status_2{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 3, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_4.begin(), return_oids_4.end()),
-                        SetArrayArgument<6>(exp_create_status_1.begin(), exp_create_status_1.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid3, 30, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_5_6.begin(), return_oids_5_6.end()),
-                        SetArrayArgument<6>(exp_create_status_2.begin(), exp_create_status_2.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
-    VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    uint32_t wcmp_group_refcount = 0;
-    uint32_t nexthop_refcount = 0;
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(3, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    // Remove WCMP group member with nexthop_id=kNexthopId1 and
-    // nexthop_id=kNexthopId3(fail) - succeed to clean up
-    wcmp_group.wcmp_group_members.clear();
-    wcmp_group.wcmp_group_members.push_back(gm1);
-    wcmp_group.wcmp_group_members.push_back(gm3);
-    exp_remove_status = {SAI_STATUS_OBJECT_IN_USE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid3, kWcmpGroupMemberOid5}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()),
-                        Return(SAI_STATUS_OBJECT_IN_USE)));
-    // Clean up - revert deletions -success
-    std::vector<sai_object_id_t> return_oids_5{kWcmpGroupMemberOid5};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_5.begin(), return_oids_5.end()),
-                        SetArrayArgument<6>(exp_create_status_1.begin(), exp_create_status_1.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_EQ(StatusCode::SWSS_RC_IN_USE, ProcessUpdateRequest(&wcmp_group));
-    P4WcmpGroupEntry expected_wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    expected_wcmp_group.wcmp_group_members.push_back(gm1);
-    expected_wcmp_group.wcmp_group_members.push_back(gm2);
-    expected_wcmp_group.wcmp_group_members.push_back(gm3);
-    // WCMP group remains as the old one
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(3, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
+  wcmp_group.wcmp_group_members.push_back(gm1);
+  wcmp_group.wcmp_group_members.push_back(gm2);
+  wcmp_group.wcmp_group_members.push_back(gm3);
 
-    // Remove WCMP group member with nexthop_id=kNexthopId1 and
-    // nexthop_id=kNexthopId3(fail) - fail to clean up
-    exp_remove_status = {SAI_STATUS_OBJECT_IN_USE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid3, kWcmpGroupMemberOid5}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()),
-                        Return(SAI_STATUS_OBJECT_IN_USE)));
-    // Clean up - revert deletions -failure
-    std::vector<sai_object_id_t> return_oids{SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_TABLE_FULL};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_TABLE_FULL)));
-    // TODO: Expect critical state.
-    EXPECT_EQ("Failed to delete WCMP group member: 'ju1u32m3.atl11:qe-3/7'",
-              ProcessUpdateRequest(&wcmp_group).message());
-    // WCMP group is as expected, but refcounts are not
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(2, wcmp_group_refcount);
-    // WCMP group is corrupt due to clean up failure
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-}
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
 
-TEST_F(WcmpManagerTest, UpdateWcmpGroupFailsWhenCreateNewGroupMemberSaiCallFails)
-{
-    AddWcmpGroupEntry1();
-    P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          wcmp_group, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
 
-    // Remove group member with nexthop_id=kNexthopId1
-    wcmp_group.wcmp_group_members.clear();
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm = createWcmpGroupMemberEntry(kNexthopId2, 15);
-    wcmp_group.wcmp_group_members.push_back(gm);
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_5{kWcmpGroupMemberOid5};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 15, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_5.begin(), return_oids_5.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
-    VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    uint32_t wcmp_group_refcount = 0;
-    uint32_t nexthop_refcount = 0;
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(1, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    // Add WCMP group member with nexthop_id=kNexthopId1, weight=3 and
-    // nexthop_id=kNexthopId3, weight=30(fail), update nexthop_id=kNexthopId2
-    // weight to 10.
-    P4WcmpGroupEntry updated_wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm1 = createWcmpGroupMemberEntry(kNexthopId1, 3);
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm2 = createWcmpGroupMemberEntry(kNexthopId2, 20);
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm3 = createWcmpGroupMemberEntry(kNexthopId3, 30);
-    updated_wcmp_group.wcmp_group_members.push_back(updated_gm1);
-    updated_wcmp_group.wcmp_group_members.push_back(updated_gm2);
-    updated_wcmp_group.wcmp_group_members.push_back(updated_gm3);
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid5}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_1{kWcmpGroupMemberOid1};
-    std::vector<sai_status_t> exp_create_status_fail{SAI_STATUS_SUCCESS, SAI_STATUS_TABLE_FULL};
-    std::vector<sai_object_id_t> return_oids_2_null{kWcmpGroupMemberOid2, SAI_NULL_OBJECT_ID};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 3, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_1.begin(), return_oids_1.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 20, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid3, 30, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_2_null.begin(), return_oids_2_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_TABLE_FULL)));
-    // Clean up - success
-    std::vector<sai_status_t> exp_remove_status_2{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2, kWcmpGroupMemberOid1}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_remove_status_2.begin(), exp_remove_status_2.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 15, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_5.begin(), return_oids_5.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_FALSE(ProcessUpdateRequest(&updated_wcmp_group).ok());
-    P4WcmpGroupEntry expected_wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> expected_gm = createWcmpGroupMemberEntry(kNexthopId2, 15);
-    expected_wcmp_group.wcmp_group_members.push_back(expected_gm);
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(1, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
+  EXPECT_TRUE(ProcessUpdateRequest(&wcmp_group).ok());
+  VerifyWcmpGroupEntry(wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
+  uint32_t wcmp_group_refcount = 0;
+  uint32_t nexthop_refcount = 0;
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
+  EXPECT_EQ(0, wcmp_group_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey1, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey2, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey3, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  // Remove WCMP group member with nexthop_id=kNexthopId1 and
+  // nexthop_id=kNexthopId3(fail) - succeed to clean up
+  wcmp_group.wcmp_group_members.clear();
+  wcmp_group.wcmp_group_members.push_back(gm1);
+  wcmp_group.wcmp_group_members.push_back(gm3);
 
-    // Try again, but this time clean up failed to remove created group member
-    exp_remove_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid5}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 3, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_1.begin(), return_oids_1.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 20, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid3, 30, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_2_null.begin(), return_oids_2_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_TABLE_FULL)));
-    // Clean up - revert creation - failure
-    std::vector<sai_status_t> exp_remove_status_fail{SAI_STATUS_OBJECT_IN_USE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2, kWcmpGroupMemberOid1}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_remove_status_fail.begin(), exp_remove_status_fail.end()),
-                        Return(SAI_STATUS_OBJECT_IN_USE)));
-    // TODO: Expect critical state.
-    EXPECT_EQ("Fail to create wcmp group member: 'ju1u32m3.atl11:qe-3/7'",
-              ProcessUpdateRequest(&updated_wcmp_group).message());
-    //  WCMP group is as expected, but refcounts are not
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(1, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount); // Corrupt status due to clean up failure
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey3, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-}
-
-TEST_F(WcmpManagerTest, UpdateWcmpGroupFailsWhenReduceGroupMemberWeightSaiCallFails)
-{
-    AddWcmpGroupEntry1();
-    P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    // Update WCMP group member to nexthop_id=kNexthopId1, weight=1(reduce) and
-    // nexthop_id=kNexthopId2, weight=10(increase), update nexthop_id=kNexthopId1
-    // weight=1(fail).
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm1 = createWcmpGroupMemberEntry(kNexthopId1, 1);
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm2 = createWcmpGroupMemberEntry(kNexthopId2, 10);
-    wcmp_group.wcmp_group_members.push_back(gm1);
-    wcmp_group.wcmp_group_members.push_back(gm2);
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_1{kWcmpGroupMemberOid1};
-    std::vector<sai_object_id_t> return_oids_null{SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    std::vector<sai_status_t> exp_create_status_fail{SAI_STATUS_NOT_SUPPORTED};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_null.begin(), return_oids_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_NOT_SUPPORTED)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_1.begin(), return_oids_1.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_NOT_SUPPORTED)));
-    EXPECT_FALSE(ProcessUpdateRequest(&wcmp_group).ok());
-    P4WcmpGroupEntry expected_wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> expected_gm1 = createWcmpGroupMemberEntry(kNexthopId1, 2);
-    std::shared_ptr<P4WcmpGroupMemberEntry> expected_gm2 = createWcmpGroupMemberEntry(kNexthopId2, 1);
-    expected_wcmp_group.wcmp_group_members.push_back(expected_gm1);
-    expected_wcmp_group.wcmp_group_members.push_back(expected_gm2);
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    uint32_t wcmp_group_refcount = 0;
-    uint32_t nexthop_refcount = 0;
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(2, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-}
-
-TEST_F(WcmpManagerTest, UpdateWcmpGroupFailsWhenIncreaseGroupMemberWeightSaiCallFails)
-{
-    AddWcmpGroupEntry1();
-    P4WcmpGroupEntry wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    // Update WCMP group member to nexthop_id=kNexthopId1, weight=1(reduce) and
-    // nexthop_id=kNexthopId2, weight=10(increase), update nexthop_id=kNexthopId2
-    // weight=10(fail).
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm1 = createWcmpGroupMemberEntry(kNexthopId1, 1);
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm2 = createWcmpGroupMemberEntry(kNexthopId2, 10);
-    wcmp_group.wcmp_group_members.push_back(gm1);
-    wcmp_group.wcmp_group_members.push_back(gm2);
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_4{kWcmpGroupMemberOid4};
-    std::vector<sai_object_id_t> return_oids_null{SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    std::vector<sai_status_t> exp_create_status_fail{SAI_STATUS_NOT_SUPPORTED};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_4.begin(), return_oids_4.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_null.begin(), return_oids_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_NOT_SUPPORTED)));
-    // Clean up modified members - success
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid4}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_1_2{kWcmpGroupMemberOid1, kWcmpGroupMemberOid2};
-    std::vector<sai_status_t> exp_create_status_2{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_1_2.begin(), return_oids_1_2.end()),
-                        SetArrayArgument<6>(exp_create_status_2.begin(), exp_create_status_2.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_FALSE(ProcessUpdateRequest(&wcmp_group).ok());
-    P4WcmpGroupEntry expected_wcmp_group = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> expected_gm1 = createWcmpGroupMemberEntry(kNexthopId1, 2);
-    std::shared_ptr<P4WcmpGroupMemberEntry> expected_gm2 = createWcmpGroupMemberEntry(kNexthopId2, 1);
-    expected_wcmp_group.wcmp_group_members.push_back(expected_gm1);
-    expected_wcmp_group.wcmp_group_members.push_back(expected_gm2);
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    uint32_t wcmp_group_refcount = 0;
-    uint32_t nexthop_refcount = 0;
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(2, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
-    // Try again, the same error happens when update and new error during clean up
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_4.begin(), return_oids_4.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_null.begin(), return_oids_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_NOT_SUPPORTED)));
-    // Clean up modified members - failure
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid4}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_2_null{SAI_NULL_OBJECT_ID, kWcmpGroupMemberOid2};
-    std::vector<sai_status_t> exp_create_status_2_fail{SAI_STATUS_NOT_SUPPORTED, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_2_null.begin(), return_oids_2_null.end()),
-                        SetArrayArgument<6>(exp_create_status_2_fail.begin(), exp_create_status_2_fail.end()),
-                        Return(SAI_STATUS_NOT_SUPPORTED)));
-
-    // TODO: Expect critical state.
-    EXPECT_EQ("Fail to create wcmp group member: 'ju1u32m2.atl11:qe-3/7'", ProcessUpdateRequest(&wcmp_group).message());
-    // weight of wcmp_group_members[kNexthopId1] unable to revert
-    // SAI object in ASIC DB: missing group member with
-    // next_hop_id=kNexthopId1
-    expected_gm1->weight = 2;
-    VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
-    EXPECT_EQ(1, wcmp_group_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &nexthop_refcount));
-    EXPECT_EQ(0, nexthop_refcount);
-    ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &nexthop_refcount));
-    EXPECT_EQ(1, nexthop_refcount);
+  exp_status = std::vector<sai_status_t>{SAI_STATUS_OBJECT_IN_USE,
+                                         SAI_STATUS_OBJECT_IN_USE};
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          wcmp_group, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_OBJECT_IN_USE)));
+  EXPECT_EQ(StatusCode::SWSS_RC_IN_USE, ProcessUpdateRequest(&wcmp_group));
+  P4WcmpGroupEntry expected_wcmp_group = {.wcmp_group_id = kWcmpGroupId1,
+                                          .wcmp_group_members = {},
+                                          .nexthop_ids = {},
+                                          .nexthop_weights = {}};
+  expected_wcmp_group.wcmp_group_members.push_back(gm1);
+  expected_wcmp_group.wcmp_group_members.push_back(gm2);
+  expected_wcmp_group.wcmp_group_members.push_back(gm3);
+  // WCMP group remains as the old one
+  VerifyWcmpGroupEntry(expected_wcmp_group, *GetWcmpGroupEntry(kWcmpGroupId1));
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP, kWcmpGroupKey1, &wcmp_group_refcount));
+  EXPECT_EQ(0, wcmp_group_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey1, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey2, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
+  ASSERT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          kNexthopKey3, &nexthop_refcount));
+  EXPECT_EQ(1, nexthop_refcount);
 }
 
 TEST_F(WcmpManagerTest, ValidateWcmpGroupEntryFailsWhenNextHopDoesNotExist)
@@ -1457,18 +802,7 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndDeleteInDrainSucceeds)
     Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND, attributes));
 
     EXPECT_CALL(mock_sai_next_hop_group_, create_next_hop_group(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, kWcmpGroupMemberOid2};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
+        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1),
                         Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(
         *gMockResponsePublisher,
@@ -1485,13 +819,6 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndDeleteInDrainSucceeds)
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &ref_cnt));
     EXPECT_EQ(1, ref_cnt);
 
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(
-                    Eq(2), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2, kWcmpGroupMemberOid1}),
-                    Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
         .WillOnce(Return(SAI_STATUS_SUCCESS));
     attributes.clear();
@@ -1509,7 +836,7 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndDeleteInDrainSucceeds)
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &ref_cnt));
     EXPECT_EQ(0, ref_cnt);
 }
-
+// divya: start from here.
 TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
 {
     const std::string kKeyPrefix = std::string(APP_P4RT_WCMP_GROUP_TABLE_NAME) + kTableKeyDelimiter;
@@ -1528,16 +855,7 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     // Create WCMP group with member {next_hop_id=kNexthopId1, weight=1}
     Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND, attributes));
     EXPECT_CALL(mock_sai_next_hop_group_, create_next_hop_group(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
+        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1),
                         Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(
         *gMockResponsePublisher,
@@ -1548,32 +866,30 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     auto *wcmp_group_entry_ptr = GetWcmpGroupEntry(kWcmpGroupId1);
     EXPECT_NE(nullptr, wcmp_group_entry_ptr);
     EXPECT_EQ(1, wcmp_group_entry_ptr->wcmp_group_members.size());
-    VerifyWcmpGroupMemberEntry(kNexthopId1, 1, wcmp_group_entry_ptr->wcmp_group_members[0]);
-    EXPECT_EQ(kWcmpGroupMemberOid1, wcmp_group_entry_ptr->wcmp_group_members[0]->member_oid);
+    VerifyWcmpGroupMemberEntry(kNexthopId1, 1,
+                               wcmp_group_entry_ptr->wcmp_group_members[0]);
     EXPECT_TRUE(p4_oid_mapper_->existsOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, key));
     uint32_t ref_cnt;
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &ref_cnt));
     EXPECT_EQ(1, ref_cnt);
 
-    // Update WCMP group with exact same members, the same entry will be removed
-    // and created again
+    // Update WCMP group with exact same members.
     Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND, attributes));
-    return_oids = {kWcmpGroupMemberOid3};
-    exp_create_status = {SAI_STATUS_SUCCESS};
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
     EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1,
+                                    *wcmp_group_entry_ptr, /*update=*/true)),
+                    _, _))
         .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(
         *gMockResponsePublisher,
         publish(Eq(APP_P4RT_TABLE_NAME), Eq(kKeyPrefix + j.dump()),
@@ -1582,8 +898,8 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     wcmp_group_entry_ptr = GetWcmpGroupEntry(kWcmpGroupId1);
     EXPECT_NE(nullptr, wcmp_group_entry_ptr);
     EXPECT_EQ(1, wcmp_group_entry_ptr->wcmp_group_members.size());
-    VerifyWcmpGroupMemberEntry(kNexthopId1, 1, wcmp_group_entry_ptr->wcmp_group_members[0]);
-    EXPECT_EQ(kWcmpGroupMemberOid3, wcmp_group_entry_ptr->wcmp_group_members[0]->member_oid);
+    VerifyWcmpGroupMemberEntry(kNexthopId1, 1,
+                               wcmp_group_entry_ptr->wcmp_group_members[0]);
     EXPECT_TRUE(p4_oid_mapper_->existsOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, key));
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &ref_cnt));
     EXPECT_EQ(1, ref_cnt);
@@ -1595,22 +911,26 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     attributes.clear();
     attributes.push_back(swss::FieldValueTuple{p4orch::kActions, actions.dump()});
     Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND, attributes));
-    return_oids = {kWcmpGroupMemberOid2};
-    exp_create_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    exp_remove_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid3}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
+
+    auto exp_group = *wcmp_group_entry_ptr;
+    exp_group.wcmp_group_members =
+        std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>>{
+            std::make_shared<P4WcmpGroupMemberEntry>()};
+    exp_group.wcmp_group_members[0]->next_hop_id = kNexthopId2;
+    exp_group.wcmp_group_members[0]->weight = 1;
+    exp_group.wcmp_group_members[0]->next_hop_oid = kNexthopOid2;
+    EXPECT_CALL(
+        mock_sai_next_hop_group_,
+        set_next_hop_groups_attribute(
+            Eq(2),
+            ArrayEq(
+                std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+            Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                            std::placeholders::_1, exp_group, /*update=*/true)),
+            _, _))
         .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(
         *gMockResponsePublisher,
         publish(Eq(APP_P4RT_TABLE_NAME), Eq(kKeyPrefix + j.dump()),
@@ -1619,8 +939,8 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     wcmp_group_entry_ptr = GetWcmpGroupEntry(kWcmpGroupId1);
     EXPECT_NE(nullptr, wcmp_group_entry_ptr);
     EXPECT_EQ(1, wcmp_group_entry_ptr->wcmp_group_members.size());
-    VerifyWcmpGroupMemberEntry(kNexthopId2, 1, wcmp_group_entry_ptr->wcmp_group_members[0]);
-    EXPECT_EQ(kWcmpGroupMemberOid2, wcmp_group_entry_ptr->wcmp_group_members[0]->member_oid);
+    VerifyWcmpGroupMemberEntry(kNexthopId2, 1,
+                               wcmp_group_entry_ptr->wcmp_group_members[0]);
     EXPECT_TRUE(p4_oid_mapper_->existsOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, key));
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &ref_cnt));
     EXPECT_EQ(0, ref_cnt);
@@ -1633,22 +953,26 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     attributes.clear();
     attributes.push_back(swss::FieldValueTuple{p4orch::kActions, actions.dump()});
     Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND, attributes));
-    return_oids = {kWcmpGroupMemberOid4};
-    exp_create_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 2, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    exp_remove_status = {SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid2}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
+
+    exp_group = *wcmp_group_entry_ptr;
+    exp_group.wcmp_group_members =
+        std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>>{
+            std::make_shared<P4WcmpGroupMemberEntry>()};
+    exp_group.wcmp_group_members[0]->next_hop_id = kNexthopId2;
+    exp_group.wcmp_group_members[0]->weight = 2;
+    exp_group.wcmp_group_members[0]->next_hop_oid = kNexthopOid2;
+    EXPECT_CALL(
+        mock_sai_next_hop_group_,
+        set_next_hop_groups_attribute(
+            Eq(2),
+            ArrayEq(
+                std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+            Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                            std::placeholders::_1, exp_group, /*update=*/true)),
+            _, _))
         .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(
         *gMockResponsePublisher,
         publish(Eq(APP_P4RT_TABLE_NAME), Eq(kKeyPrefix + j.dump()),
@@ -1657,8 +981,8 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     wcmp_group_entry_ptr = GetWcmpGroupEntry(kWcmpGroupId1);
     EXPECT_NE(nullptr, wcmp_group_entry_ptr);
     EXPECT_EQ(1, wcmp_group_entry_ptr->wcmp_group_members.size());
-    VerifyWcmpGroupMemberEntry(kNexthopId2, 2, wcmp_group_entry_ptr->wcmp_group_members[0]);
-    EXPECT_EQ(kWcmpGroupMemberOid4, wcmp_group_entry_ptr->wcmp_group_members[0]->member_oid);
+    VerifyWcmpGroupMemberEntry(kNexthopId2, 2,
+                               wcmp_group_entry_ptr->wcmp_group_members[0]);
     EXPECT_TRUE(p4_oid_mapper_->existsOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, key));
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, &ref_cnt));
     EXPECT_EQ(1, ref_cnt);
@@ -1819,28 +1143,61 @@ TEST_F(WcmpManagerTest, PruneNextHopSucceeds)
     P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name, true);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group_member(Eq(kWcmpGroupMemberOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = true;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     // Prune next hops associated with port
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
-TEST_F(WcmpManagerTest, PruneNextHopFailsWithNextHopRemovalFailure)
-{
-    // Add member with operationally up watch port
-    std::string port_name = "Ethernet6";
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name, true);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group_member(Eq(kWcmpGroupMemberOid1)))
-        .WillOnce(Return(SAI_STATUS_FAILURE));
-    // TODO: Expect critical state.
-    // Prune next hops associated with port (fails)
-    PruneNextHops(port_name);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
+TEST_F(WcmpManagerTest, PruneNextHopFails) {
+  // Add member with operationally up watch port
+  std::string port_name = "Ethernet6";
+  P4WcmpGroupEntry app_db_entry =
+      AddWcmpGroupEntryWithWatchport(port_name, true);
+  EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
+                                             true, 1));
+  EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
+
+  bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+  app_db_entry.wcmp_group_members[0]->pruned = true;
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_FAILURE};
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          app_db_entry, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
+  // TODO: Expect critical state.
+  // Prune next hops associated with port (fails)
+  PruneNextHops(port_name);
+  EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
+                                             true, 1));
+  EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
 TEST_F(WcmpManagerTest, RestorePrunedNextHopSucceeds)
@@ -1852,11 +1209,24 @@ TEST_F(WcmpManagerTest, RestorePrunedNextHopSucceeds)
     P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
+
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = false;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
     EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_member(_, Eq(gSwitchId), Eq(3),
-                                             Truly(std::bind(MatchSaiNextHopGroupMemberAttribute, kNexthopOid1, 2,
-                                                             kWcmpGroupOid1, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupMemberOid1), Return(SAI_STATUS_SUCCESS)));
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     // Restore next hops associated with port
     RestorePrunedNextHops(port_name);
@@ -1864,83 +1234,37 @@ TEST_F(WcmpManagerTest, RestorePrunedNextHopSucceeds)
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
-TEST_F(WcmpManagerTest, RestorePrunedNextHopFailsWithNoOidMappingForWcmpGroup)
-{
-    // Add member with operationally down watch port. Since associated watchport
-    // is operationally down, member will not be created in SAI but will be
-    // directly added to the pruned set of WCMP group members.
-    std::string port_name = "Ethernet1";
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
-    p4_oid_mapper_->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroupId1));
-    // TODO: Expect critical state.
-    RestorePrunedNextHops(port_name);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
-}
+TEST_F(WcmpManagerTest, RestorePrunedNextHopFails) {
+  // Add member with operationally down watch port. Since associated watchport
+  // is operationally down, member will not be created in SAI but will be
+  // directly added to the pruned set of WCMP group members.
+  std::string port_name = "Ethernet1";
+  P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name);
+  EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
+                                             true, 1));
+  EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 
-TEST_F(WcmpManagerTest, RestorePrunedNextHopFailsWithNextHopCreationFailure)
-{
-    // Add member with operationally down watch port. Since associated watchport
-    // is operationally down, member will not be created in SAI but will be
-    // directly added to the pruned set of WCMP group members.
-    std::string port_name = "Ethernet1";
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_member(_, Eq(gSwitchId), Eq(3),
-                                             Truly(std::bind(MatchSaiNextHopGroupMemberAttribute, kNexthopOid1, 2,
-                                                             kWcmpGroupOid1, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupMemberOid1), Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    RestorePrunedNextHops(port_name);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
-}
+  bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+  app_db_entry.wcmp_group_members[0]->pruned = false;
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_FAILURE};
 
-TEST_F(WcmpManagerTest, CreateGroupWithWatchportFailsWithNextHopCreationFailure)
-{
-    // Add member with operationally up watch port
-    // Create WCMP group with members kNexthopId1 and kNexthopId2 (fails)
-    std::string port_name = "Ethernet6";
-    P4WcmpGroupEntry app_db_entry = {.wcmp_group_id = kWcmpGroupId1, .wcmp_group_members = {}};
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm1 =
-        createWcmpGroupMemberEntryWithWatchport(kNexthopId1, 1, port_name, kWcmpGroupId1, kNexthopOid1);
-    app_db_entry.wcmp_group_members.push_back(gm1);
-    std::shared_ptr<P4WcmpGroupMemberEntry> gm2 =
-        createWcmpGroupMemberEntryWithWatchport(kNexthopId2, 1, port_name, kWcmpGroupId1, kNexthopOid2);
-    app_db_entry.wcmp_group_members.push_back(gm2);
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group(_, Eq(gSwitchId), Eq(1),
-                                      Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupOid1), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1, SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(2), ArrayEq(std::vector<uint32_t>{3, 3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1),
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // Clean up created members
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, ProcessAddRequest(&app_db_entry));
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(gm1, false, 0));
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(gm2, false, 0));
-    EXPECT_FALSE(gm1->pruned);
-    EXPECT_FALSE(gm2->pruned);
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          Truly(std::bind(MatchSaiNextHopGroupAttribute, std::placeholders::_1,
+                          app_db_entry, /*update=*/true)),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
+  // TODO: Expect critical state.
+  RestorePrunedNextHops(port_name);
+  EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
+                                             true, 1));
+  EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
 TEST_F(WcmpManagerTest, RemoveWcmpGroupAfterPruningSucceeds)
@@ -1950,8 +1274,25 @@ TEST_F(WcmpManagerTest, RemoveWcmpGroupAfterPruningSucceeds)
     P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name, true);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group_member(Eq(kWcmpGroupMemberOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = true;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
@@ -2023,11 +1364,24 @@ TEST_F(WcmpManagerTest, RemoveNextHopWithRestoredPrunedMember)
     EXPECT_EQ(1, ref_cnt);
 
     // Restore member associated with port.
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = false;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
     EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_member(_, Eq(gSwitchId), Eq(3),
-                                             Truly(std::bind(MatchSaiNextHopGroupMemberAttribute, kNexthopOid1, 2,
-                                                             kWcmpGroupOid1, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupMemberOid1), Return(SAI_STATUS_SUCCESS)));
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     RestorePrunedNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
@@ -2037,12 +1391,6 @@ TEST_F(WcmpManagerTest, RemoveNextHopWithRestoredPrunedMember)
     EXPECT_EQ(1, ref_cnt);
 
     // Remove Wcmp group.
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group(Eq(kWcmpGroupOid1)))
         .WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, RemoveWcmpGroup(kWcmpGroupId1));
@@ -2067,8 +1415,24 @@ TEST_F(WcmpManagerTest, VerifyNextHopRefCountWhenMemberPruned)
     EXPECT_EQ(1, ref_cnt);
 
     // Prune member associated with port.
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group_member(Eq(kWcmpGroupMemberOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = true;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
@@ -2092,22 +1456,23 @@ TEST_F(WcmpManagerTest, UpdateWcmpGroupWithOperationallyUpWatchportMemberSucceed
     std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm =
         createWcmpGroupMemberEntryWithWatchport(kNexthopId2, 1, port_name, kWcmpGroupId1, kNexthopOid2);
     updated_app_db_entry.wcmp_group_members.push_back(updated_gm);
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid2};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+
     EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, updated_app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
         .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessUpdateRequest(&updated_app_db_entry));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], false, 1));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_gm, true, 1));
@@ -2125,13 +1490,28 @@ TEST_F(WcmpManagerTest, UpdateWcmpGroupWithOperationallyDownWatchportMemberSucce
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 
-    // Update WCMP group to remove kNexthopId1 and add kNexthopId2. No SAI calls
-    // are expected as the associated watch port is operationally down.
+    // Update WCMP group to remove kNexthopId1 and add kNexthopId2.
     P4WcmpGroupEntry updated_app_db_entry;
     updated_app_db_entry.wcmp_group_id = kWcmpGroupId1;
     std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm =
         createWcmpGroupMemberEntryWithWatchport(kNexthopId2, 1, port_name, kWcmpGroupId1, kNexthopOid2);
     updated_app_db_entry.wcmp_group_members.push_back(updated_gm);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, updated_app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessUpdateRequest(&updated_app_db_entry));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], false, 1));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_gm, true, 1));
@@ -2152,30 +1532,43 @@ TEST_F(WcmpManagerTest, PruneAfterWcmpGroupUpdateSucceeds)
     std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm =
         createWcmpGroupMemberEntryWithWatchport(kNexthopId1, 10, port_name, kWcmpGroupId1, kNexthopOid1);
     updated_app_db_entry.wcmp_group_members.push_back(updated_gm);
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
     EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, updated_app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
         .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids{kWcmpGroupMemberOid1};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids.begin(), return_oids.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessUpdateRequest(&updated_app_db_entry));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], false, 1));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(updated_app_db_entry.wcmp_group_members[0]->pruned);
 
     // Prune members associated with port.
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group_member(Eq(kWcmpGroupMemberOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    bool pruned = updated_app_db_entry.wcmp_group_members[0]->pruned;
+    updated_app_db_entry.wcmp_group_members[0]->pruned = true;
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, updated_app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    updated_app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(updated_app_db_entry.wcmp_group_members[0]->pruned);
@@ -2207,6 +1600,22 @@ TEST_F(WcmpManagerTest, PrunedMemberUpdateOnRestoreSucceeds)
     std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm =
         createWcmpGroupMemberEntryWithWatchport(kNexthopId1, 10, port_name, kWcmpGroupId1, kNexthopOid1);
     updated_app_db_entry.wcmp_group_members.push_back(updated_gm);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, updated_app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessUpdateRequest(&updated_app_db_entry));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], false, 1));
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_app_db_entry.wcmp_group_members[0], true, 1));
@@ -2214,123 +1623,25 @@ TEST_F(WcmpManagerTest, PrunedMemberUpdateOnRestoreSucceeds)
 
     // Restore members associated with port.
     // Verify that the weight of the restored member is updated.
+    bool pruned = updated_app_db_entry.wcmp_group_members[0]->pruned;
+    updated_app_db_entry.wcmp_group_members[0]->pruned = false;
     EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_member(_, Eq(gSwitchId), Eq(3),
-                                             Truly(std::bind(MatchSaiNextHopGroupMemberAttribute, kNexthopOid1, 10,
-                                                             kWcmpGroupOid1, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupMemberOid1), Return(SAI_STATUS_SUCCESS)));
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, updated_app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    updated_app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     RestorePrunedNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(updated_app_db_entry.wcmp_group_members[0]->pruned);
-}
-
-TEST_F(WcmpManagerTest, UpdateWcmpGroupWithOperationallyUpWatchportMemberFailsWithMemberRemovalFailure)
-{
-    // Add member with operationally up watch port
-    std::string port_name = "Ethernet6";
-    P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name, true);
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-
-    // Update WCMP group to remove kNexthopId1(fails) and add kNexthopId2
-    P4WcmpGroupEntry updated_app_db_entry;
-    updated_app_db_entry.wcmp_group_id = kWcmpGroupId1;
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm2 =
-        createWcmpGroupMemberEntryWithWatchport(kNexthopId2, 10, port_name, kWcmpGroupId1, kNexthopOid2);
-    std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm1 =
-        createWcmpGroupMemberEntryWithWatchport(kNexthopId1, 1, port_name, kWcmpGroupId1, kNexthopOid1);
-    updated_app_db_entry.wcmp_group_members.push_back(updated_gm1);
-    updated_app_db_entry.wcmp_group_members.push_back(updated_gm2);
-    std::vector<sai_status_t> exp_remove_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    std::vector<sai_object_id_t> return_oids_4{kWcmpGroupMemberOid4};
-    std::vector<sai_object_id_t> return_oids_null{SAI_NULL_OBJECT_ID};
-    std::vector<sai_status_t> exp_create_status{SAI_STATUS_SUCCESS};
-    std::vector<sai_status_t> exp_create_status_fail{SAI_STATUS_INSUFFICIENT_RESOURCES};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_4.begin(), return_oids_4.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_null.begin(), return_oids_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_INSUFFICIENT_RESOURCES)));
-    // Clean up created member-succeeds
-    std::vector<sai_object_id_t> return_oids_1{kWcmpGroupMemberOid1};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_1.begin(), return_oids_1.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid4}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, ProcessUpdateRequest(&updated_app_db_entry));
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_gm2, false, 1));
-    EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-    EXPECT_FALSE(updated_gm2->pruned);
-
-    // Update again, this time clean up fails
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid1}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 1, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_4.begin(), return_oids_4.end()),
-                        SetArrayArgument<6>(exp_create_status.begin(), exp_create_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid2, 10, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_null.begin(), return_oids_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_INSUFFICIENT_RESOURCES)));
-    // Clean up created member(fails)
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                remove_next_hop_group_members(Eq(1), ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupMemberOid4}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _))
-        .WillOnce(
-            DoAll(SetArrayArgument<3>(exp_remove_status.begin(), exp_remove_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_members(Eq(gSwitchId), Eq(1), ArrayEq(std::vector<uint32_t>{3}),
-                                              AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                                                  GetSaiNextHopGroupMemberAttribute(kNexthopOid1, 2, kWcmpGroupOid1)}),
-                                              Eq(SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR), _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(return_oids_null.begin(), return_oids_null.end()),
-                        SetArrayArgument<6>(exp_create_status_fail.begin(), exp_create_status_fail.end()),
-                        Return(SAI_STATUS_INSUFFICIENT_RESOURCES)));
-    // TODO: Expect critical state.
-    EXPECT_EQ("Fail to create wcmp group member: 'ju1u32m2.atl11:qe-3/7'",
-              ProcessUpdateRequest(&updated_app_db_entry).message());
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], false, 0));
-    EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_gm2, false, 0));
-    EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-    EXPECT_FALSE(updated_gm2->pruned);
 }
 
 TEST_F(WcmpManagerTest, WatchportStateChangetoOperDownSucceeds)
@@ -2346,8 +1657,25 @@ TEST_F(WcmpManagerTest, WatchportStateChangetoOperDownSucceeds)
     std::string op = "port_state_change";
     std::string data = "[{\"port_id\":\"oid:0x56789abcdff\",\"port_state\":\"SAI_PORT_OPER_"
                        "STATUS_DOWN\",\"port_error_status\":\"0\"}]";
-    EXPECT_CALL(mock_sai_next_hop_group_, remove_next_hop_group_member(Eq(kWcmpGroupMemberOid1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = false;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_next_hop_group_,
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     HandlePortStatusChangeNotification(op, data);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
@@ -2369,11 +1697,25 @@ TEST_F(WcmpManagerTest, WatchportStateChangeToOperUpSucceeds)
     std::string op = "port_state_change";
     std::string data = "[{\"port_id\":\"oid:0x112233\",\"port_state\":\"SAI_PORT_OPER_"
                        "STATUS_UP\",\"port_error_status\":\"0\"}]";
+
+    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
+    app_db_entry.wcmp_group_members[0]->pruned = true;
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
     EXPECT_CALL(mock_sai_next_hop_group_,
-                create_next_hop_group_member(_, Eq(gSwitchId), Eq(3),
-                                             Truly(std::bind(MatchSaiNextHopGroupMemberAttribute, kNexthopOid1, 2,
-                                                             kWcmpGroupOid1, std::placeholders::_1))))
-        .WillOnce(DoAll(SetArgPointee<0>(kWcmpGroupMemberOid1), Return(SAI_STATUS_SUCCESS)));
+                set_next_hop_groups_attribute(
+                    Eq(2),
+                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
+                                                         kWcmpGroupOid1}),
+                    Truly(std::bind(MatchSaiNextHopGroupAttribute,
+                                    std::placeholders::_1, app_db_entry,
+                                    /*update=*/true)),
+                    _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    app_db_entry.wcmp_group_members[0]->pruned = pruned;
+
     HandlePortStatusChangeNotification(op, data);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
@@ -2410,14 +1752,15 @@ TEST_F(WcmpManagerTest, VerifyStateTest)
 
     // Setup ASIC DB.
     swss::Table table(nullptr, "ASIC_STATE");
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
-                  "SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"}});
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:oid:0xb",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0xa"},
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x1"},
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT", "2"}});
+    table.set(
+        "SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+        std::vector<swss::FieldValueTuple>{
+            swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_TYPE",
+                                  "SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS"},
+            swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST",
+                                  "1:oid:0x1"},
+            swss::FieldValueTuple{
+                "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST", "1:2"}});
 
     // Verification should succeed with vaild key and value.
     nlohmann::json actions;
@@ -2504,13 +1847,14 @@ TEST_F(WcmpManagerTest, VerifyStateTest)
     EXPECT_FALSE(VerifyState(db_key, attributes).empty());
     wcmp_group_entry_ptr->wcmp_group_members[0]->wcmp_group_id = saved_member_wcmp_group_id;
 
-    // Verification should fail if member OID mapper mismatches.
-    p4_oid_mapper_->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-                             kWcmpGroupKey1 + kTableKeyDelimiter + sai_serialize_object_id(kWcmpGroupMemberOid1));
+    // Verification should fail if nexthop OID mismatches.
+    p4_oid_mapper_->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1);
+    p4_oid_mapper_->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1);
+
     EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-                           kWcmpGroupKey1 + kTableKeyDelimiter + sai_serialize_object_id(kWcmpGroupMemberOid1),
-                           kWcmpGroupMemberOid1);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1,
+                           kNexthopOid1);
+    p4_oid_mapper_->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1);
 }
 
 TEST_F(WcmpManagerTest, VerifyStateAsicDbTest)
@@ -2532,14 +1876,15 @@ TEST_F(WcmpManagerTest, VerifyStateAsicDbTest)
 
     // Setup ASIC DB.
     swss::Table table(nullptr, "ASIC_STATE");
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
-                  "SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"}});
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:oid:0xb",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0xa"},
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x1"},
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT", "2"}});
+    table.set(
+        "SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+        std::vector<swss::FieldValueTuple>{
+            swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_TYPE",
+                                  "SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS"},
+            swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST",
+                                  "1:oid:0x1"},
+            swss::FieldValueTuple{
+                "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST", "1:2"}});
 
     // Verification should succeed with correct ASIC DB values.
     EXPECT_EQ(VerifyState(db_key, attributes), "");
@@ -2548,27 +1893,43 @@ TEST_F(WcmpManagerTest, VerifyStateAsicDbTest)
     table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
               std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_TYPE", "invalid"}});
     EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+                  "SAI_NEXT_HOP_GROUP_ATTR_TYPE",
+                  "SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS"}});
+
+    // Verification should fail if member OID list mismatch.
+    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+                  "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST", "1:oid:0x2"}});
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+                  "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST", "1:oid:0x1"}});
+
+    // Verification should fail if member weight list mismatch.
+    table.set(
+        "SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+        std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+            "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST", "1:1"}});
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    table.set(
+        "SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+        std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+            "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST", "1:2"}});
 
     // Verification should fail if group table is missing.
     table.del("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa");
     EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
-                  "SAI_NEXT_HOP_GROUP_ATTR_TYPE", "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"}});
-
-    // Verification should fail if member values mismatch.
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:oid:0xb",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT", "1"}});
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-
-    // Verification should fail if member table is missing.
-    table.del("SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:oid:0xb");
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    table.set("SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER:oid:0xb",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID", "oid:0xa"},
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID", "oid:0x1"},
-                  swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT", "2"}});
+    table.set(
+        "SAI_OBJECT_TYPE_NEXT_HOP_GROUP:oid:0xa",
+        std::vector<swss::FieldValueTuple>{
+            swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_TYPE",
+                                  "SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS"},
+            swss::FieldValueTuple{"SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST",
+                                  "1:oid:0x1"},
+            swss::FieldValueTuple{
+                "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST", "1:2"}});
 }
 
 } // namespace test

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -23,8 +23,7 @@ using ::p4orch::kTableKeyDelimiter;
 extern sai_object_id_t gSwitchId;
 extern sai_next_hop_group_api_t *sai_next_hop_group_api;
 extern CrmOrch *gCrmOrch;
-extern PortsOrch *gPortsOrch;
-extern size_t gMaxBulkSize;
+extern PortsOrch* gPortsOrch;
 
 namespace p4orch
 {
@@ -32,60 +31,64 @@ namespace p4orch
 namespace
 {
 
-std::string getWcmpGroupMemberKey(const std::string &wcmp_group_key, const sai_object_id_t wcmp_member_oid)
-{
-    return wcmp_group_key + kTableKeyDelimiter + sai_serialize_object_id(wcmp_member_oid);
-}
+std::vector<sai_attribute_t> prepareSaiGroupAttrs(
+    P4WcmpGroupEntry& wcmp_group_entry, bool update = false) {
+  std::vector<sai_attribute_t> attrs;
+  sai_attribute_t attr;
 
-std::vector<sai_attribute_t> getSaiGroupAttrs(const P4WcmpGroupEntry &wcmp_group_entry)
-{
-    std::vector<sai_attribute_t> attrs;
-    sai_attribute_t attr;
-
-    // TODO: Update type to WCMP when SAI supports it.
+  if (!update) {
     attr.id = SAI_NEXT_HOP_GROUP_ATTR_TYPE;
-    attr.value.s32 = SAI_NEXT_HOP_GROUP_TYPE_ECMP;
+    attr.value.s32 = SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS;
     attrs.push_back(attr);
+  }
 
-    return attrs;
+  uint32_t count = 0;
+  wcmp_group_entry.nexthop_ids.clear();
+  wcmp_group_entry.nexthop_weights.clear();
+  for (const auto& member : wcmp_group_entry.wcmp_group_members) {
+    if (!member->pruned) {
+      wcmp_group_entry.nexthop_ids.push_back(member->next_hop_oid);
+      wcmp_group_entry.nexthop_weights.push_back(member->weight);
+      count++;
+    }
+  }
+
+  sai_attribute_t nhl, nhmwl;
+  nhl.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
+  nhmwl.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST;
+  nhl.value.objlist.count = count;
+  nhmwl.value.u32list.count = count;
+  if (count) {
+    nhl.value.objlist.list = wcmp_group_entry.nexthop_ids.data();
+    nhmwl.value.u32list.list = wcmp_group_entry.nexthop_weights.data();
+  } else {
+    nhl.value.objlist.list = nullptr;
+    nhmwl.value.u32list.list = nullptr;
+  }
+  attrs.push_back(nhl);
+  attrs.push_back(nhmwl);
+
+  return attrs;
 }
 
-} // namespace
-
-WcmpManager::WcmpManager(P4OidMapper *p4oidMapper, ResponsePublisherInterface *publisher)
-    : gNextHopGroupMemberBulker(sai_next_hop_group_api, gSwitchId, gMaxBulkSize)
-{
-    SWSS_LOG_ENTER();
-
-    assert(p4oidMapper != nullptr);
-    m_p4OidMapper = p4oidMapper;
-    assert(publisher != nullptr);
-    m_publisher = publisher;
+ReturnCode updateGroup(P4WcmpGroupEntry& wcmp_group) {
+  auto attrs = prepareSaiGroupAttrs(wcmp_group, /*update=*/true);
+  std::vector<sai_object_id_t> oids(attrs.size());
+  std::vector<sai_status_t> status(attrs.size());
+  for (size_t i = 0; i < attrs.size(); ++i) {
+    oids[i] = wcmp_group.wcmp_group_oid;
+  }
+  // This SAI operation is assumed to be atomic.
+  CHECK_ERROR_AND_LOG_AND_RETURN(
+      sai_next_hop_group_api->set_next_hop_groups_attribute(
+          uint32_t(attrs.size()), oids.data(), attrs.data(),
+          SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR, status.data()),
+      "Failed to update next hop group  "
+          << QuotedVar(wcmp_group.wcmp_group_id));
+  return ReturnCode();
 }
 
-std::vector<sai_attribute_t> WcmpManager::getSaiMemberAttrs(const P4WcmpGroupMemberEntry &wcmp_member_entry,
-                                                            const sai_object_id_t group_oid)
-{
-    std::vector<sai_attribute_t> attrs;
-    sai_attribute_t attr;
-    sai_object_id_t next_hop_oid = SAI_NULL_OBJECT_ID;
-    m_p4OidMapper->getOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(wcmp_member_entry.next_hop_id),
-                          &next_hop_oid);
-
-    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID;
-    attr.value.oid = group_oid;
-    attrs.push_back(attr);
-
-    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID;
-    attr.value.oid = next_hop_oid;
-    attrs.push_back(attr);
-
-    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT;
-    attr.value.u32 = (uint32_t)wcmp_member_entry.weight;
-    attrs.push_back(attr);
-
-    return attrs;
-}
+}  // namespace
 
 ReturnCode WcmpManager::validateWcmpGroupEntry(const P4WcmpGroupEntry &app_db_entry)
 {
@@ -218,24 +221,6 @@ ReturnCode WcmpManager::processAddRequest(P4WcmpGroupEntry *app_db_entry)
     return status;
 }
 
-ReturnCode WcmpManager::createWcmpGroupMember(std::shared_ptr<P4WcmpGroupMemberEntry> wcmp_group_member,
-                                              const sai_object_id_t group_oid, const std::string &wcmp_group_key)
-{
-    auto attrs = getSaiMemberAttrs(*wcmp_group_member, group_oid);
-
-    CHECK_ERROR_AND_LOG_AND_RETURN(
-        sai_next_hop_group_api->create_next_hop_group_member(&wcmp_group_member->member_oid, gSwitchId,
-                                                             (uint32_t)attrs.size(), attrs.data()),
-        "Failed to create next hop group member " << QuotedVar(wcmp_group_member->next_hop_id));
-
-    // Update reference count
-    m_p4OidMapper->setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-                          getWcmpGroupMemberKey(wcmp_group_key, wcmp_group_member->member_oid),
-                          wcmp_group_member->member_oid);
-    m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
-    return ReturnCode();
-}
-
 void WcmpManager::insertMemberInPortNameToWcmpGroupMemberMap(std::shared_ptr<P4WcmpGroupMemberEntry> member)
 {
     port_name_to_wcmp_group_member_map[member->watch_port].insert(member);
@@ -279,148 +264,49 @@ ReturnCode WcmpManager::fetchPortOperStatus(const std::string &port_name, sai_po
     return ReturnCode();
 }
 
-ReturnCode WcmpManager::processWcmpGroupMembersAddition(
-    const std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> &members, const std::string &wcmp_group_key,
-    sai_object_id_t wcmp_group_oid, std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> &created_wcmp_group_members)
-{
-    SWSS_LOG_ENTER();
-    ReturnCode status;
-    vector<sai_object_id_t> nhgm_ids(members.size(), SAI_NULL_OBJECT_ID);
-    for (size_t i = 0; i < members.size(); ++i)
-    {
-        bool insert_member = true;
-        auto &member = members[i];
-        if (!member->watch_port.empty())
-        {
-            // Create member in SAI only for operationally up ports
-            sai_port_oper_status_t oper_status = SAI_PORT_OPER_STATUS_DOWN;
-            status = fetchPortOperStatus(member->watch_port, &oper_status);
-            if (!status.ok())
-            {
-                break;
-            }
+ReturnCode WcmpManager::fetchMemberInfo(P4WcmpGroupEntry* wcmp_group) {
+  for (auto& member : wcmp_group->wcmp_group_members) {
+    if (!member->watch_port.empty()) {
+      sai_port_oper_status_t oper_status = SAI_PORT_OPER_STATUS_DOWN;
+      RETURN_IF_ERROR(fetchPortOperStatus(member->watch_port, &oper_status));
+      if (oper_status != SAI_PORT_OPER_STATUS_UP) {
+        member->pruned = true;
+      }
+    }
 
-            if (oper_status != SAI_PORT_OPER_STATUS_UP)
-            {
-                insert_member = false;
-                member->pruned = true;
-                SWSS_LOG_NOTICE("Member %s in group %s not created in asic as the associated "
-                                "watchport "
-                                "(%s) is not operationally up",
-                                member->next_hop_id.c_str(), member->wcmp_group_id.c_str(), member->watch_port.c_str());
-            }
-        }
-        if (insert_member)
-        {
-            auto attrs = getSaiMemberAttrs(*(member.get()), wcmp_group_oid);
-            gNextHopGroupMemberBulker.create_entry(&nhgm_ids[i], (uint32_t)attrs.size(), attrs.data());
-        }
-    }
-    if (status.ok())
-    {
-        gNextHopGroupMemberBulker.flush();
-        for (size_t i = 0; i < members.size(); ++i)
-        {
-            auto &member = members[i];
-            if (!member->pruned)
-            {
-                if (nhgm_ids[i] == SAI_NULL_OBJECT_ID)
-                {
-                    if (status.ok())
-                    {
-                        status = ReturnCode(StatusCode::SWSS_RC_UNKNOWN)
-                                 << "Fail to create wcmp group member: " << QuotedVar(member->next_hop_id);
-                    }
-                    else
-                    {
-                        status << "; Fail to create wcmp group member: " << QuotedVar(member->next_hop_id);
-                    }
-                    continue;
-                }
-                member->member_oid = nhgm_ids[i];
-                m_p4OidMapper->setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-                                      getWcmpGroupMemberKey(wcmp_group_key, member->member_oid), member->member_oid);
-                m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
-            }
-            if (!member->watch_port.empty())
-            {
-                // Add member to port_name_to_wcmp_group_member_map
-                insertMemberInPortNameToWcmpGroupMemberMap(member);
-            }
-            const std::string &next_hop_key = KeyGenerator::generateNextHopKey(member->next_hop_id);
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
-            m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
-            created_wcmp_group_members.push_back(member);
-        }
-    }
-    return status;
+    m_p4OidMapper->getOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                          KeyGenerator::generateNextHopKey(member->next_hop_id),
+                          &(member->next_hop_oid));
+  }
+  return ReturnCode();
 }
 
 ReturnCode WcmpManager::createWcmpGroup(P4WcmpGroupEntry *wcmp_group)
 {
     SWSS_LOG_ENTER();
+    RETURN_IF_ERROR(fetchMemberInfo(wcmp_group));
 
-    auto attrs = getSaiGroupAttrs(*wcmp_group);
+    auto attrs = prepareSaiGroupAttrs(*wcmp_group);
+
     CHECK_ERROR_AND_LOG_AND_RETURN(sai_next_hop_group_api->create_next_hop_group(&wcmp_group->wcmp_group_oid, gSwitchId,
                                                                                  (uint32_t)attrs.size(), attrs.data()),
                                    "Failed to create next hop group  " << QuotedVar(wcmp_group->wcmp_group_id));
+
     // Update reference count
     const auto &wcmp_group_key = KeyGenerator::generateWcmpGroupKey(wcmp_group->wcmp_group_id);
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
     m_p4OidMapper->setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key, wcmp_group->wcmp_group_oid);
-
-    // Create next hop group members
-    std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> created_wcmp_group_members;
-    ReturnCode status = processWcmpGroupMembersAddition(wcmp_group->wcmp_group_members, wcmp_group_key,
-                                                        wcmp_group->wcmp_group_oid, created_wcmp_group_members);
-    if (!status.ok())
-    {
-        // Clean up created group members and the group
-        recoverGroupMembers(wcmp_group, wcmp_group_key, created_wcmp_group_members, {});
-        auto sai_status = sai_next_hop_group_api->remove_next_hop_group(wcmp_group->wcmp_group_oid);
-        if (sai_status != SAI_STATUS_SUCCESS)
-        {
-            std::stringstream ss;
-            ss << "Failed to delete WCMP group with id " << QuotedVar(wcmp_group->wcmp_group_id);
-            SWSS_LOG_ERROR("%s SAI_STATUS: %s", ss.str().c_str(), sai_serialize_status(sai_status).c_str());
-            SWSS_RAISE_CRITICAL_STATE(ss.str());
-        }
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
-        m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
-        return status;
+    for (auto& member : wcmp_group->wcmp_group_members) {
+      const std::string& next_hop_key =
+          KeyGenerator::generateNextHopKey(member->next_hop_id);
+      gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+      m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
+      if (!member->watch_port.empty()) {
+        insertMemberInPortNameToWcmpGroupMemberMap(member);
+      }
     }
-
     m_wcmpGroupTable[wcmp_group->wcmp_group_id] = *wcmp_group;
     return ReturnCode();
-}
-
-void WcmpManager::recoverGroupMembers(
-    p4orch::P4WcmpGroupEntry *wcmp_group_entry, const std::string &wcmp_group_key,
-    const std::vector<std::shared_ptr<p4orch::P4WcmpGroupMemberEntry>> &created_wcmp_group_members,
-    const std::vector<std::shared_ptr<p4orch::P4WcmpGroupMemberEntry>> &removed_wcmp_group_members)
-{
-    SWSS_LOG_ENTER();
-    std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> members;
-    ReturnCode recovery_status;
-    // Clean up created group members - remove created new members
-    if (created_wcmp_group_members.size() != 0)
-    {
-        recovery_status = processWcmpGroupMembersRemoval(created_wcmp_group_members, wcmp_group_key, members)
-                              .prepend("Error during recovery: ");
-    }
-
-    // Clean up removed group members - create removed old members
-    if (recovery_status.ok() && removed_wcmp_group_members.size() != 0)
-    {
-        recovery_status = processWcmpGroupMembersAddition(removed_wcmp_group_members, wcmp_group_key,
-                                                          wcmp_group_entry->wcmp_group_oid, members)
-                              .prepend("Error during recovery: ");
-    }
-
-    if (!recovery_status.ok())
-    {
-        SWSS_RAISE_CRITICAL_STATE(recovery_status.message());
-    }
 }
 
 ReturnCode WcmpManager::processUpdateRequest(P4WcmpGroupEntry *wcmp_group_entry)
@@ -428,177 +314,31 @@ ReturnCode WcmpManager::processUpdateRequest(P4WcmpGroupEntry *wcmp_group_entry)
     SWSS_LOG_ENTER();
     auto *old_wcmp = getWcmpGroupEntry(wcmp_group_entry->wcmp_group_id);
     wcmp_group_entry->wcmp_group_oid = old_wcmp->wcmp_group_oid;
-    const auto &wcmp_group_key = KeyGenerator::generateWcmpGroupKey(wcmp_group_entry->wcmp_group_id);
-    // Keep record of created next hop group members
-    std::vector<std::shared_ptr<p4orch::P4WcmpGroupMemberEntry>> created_wcmp_group_members;
-    // Keep record of removed next hop group members
-    std::vector<std::shared_ptr<p4orch::P4WcmpGroupMemberEntry>> removed_wcmp_group_members;
+    RETURN_IF_ERROR(fetchMemberInfo(wcmp_group_entry));
+    RETURN_IF_ERROR(updateGroup(*wcmp_group_entry));
 
-    // Update group members steps:
-    // 1. Find the old member in the list with the smallest weight
-    // 2. Find the new member in the list with the smallest weight
-    // 3. Make SAI calls to remove old members except the reserved member with the
-    // smallest weight
-    // 4. Make SAI call to create the new member with the smallest weight
-    // 5. Make SAI call to remove the reserved old member
-    // 6. Make SAI calls to create remaining new members
-    ReturnCode update_request_status;
-    auto find_smallest_index = [&](p4orch::P4WcmpGroupEntry *wcmp,
-                                   std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> &other_members) -> int {
-        other_members.clear();
-        if (wcmp->wcmp_group_members.empty())
-        {
-            return -1;
-        }
-        int reserved_idx = 0;
-        for (int i = 1; i < (int)wcmp->wcmp_group_members.size(); i++)
-        {
-            if (wcmp->wcmp_group_members[i]->weight < wcmp->wcmp_group_members[reserved_idx]->weight)
-            {
-                other_members.push_back(wcmp->wcmp_group_members[reserved_idx]);
-                reserved_idx = i;
-            }
-            else
-            {
-                other_members.push_back(wcmp->wcmp_group_members[i]);
-            }
-        }
-        return reserved_idx;
-    };
-    // Find the old member who has the smallest weight, -1 if the member list is
-    // empty
-    std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> other_old_members;
-    int reserved_old_member_index = find_smallest_index(old_wcmp, other_old_members);
-    // Find the new member who has the smallest weight, -1 if the member list is
-    // empty
-    std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> other_new_members;
-    int reserved_new_member_index = find_smallest_index(wcmp_group_entry, other_new_members);
-
-    // Remove stale group members except the member with the smallest weight
-    if (other_old_members.size() != 0)
-    {
-        update_request_status =
-            processWcmpGroupMembersRemoval(other_old_members, wcmp_group_key, removed_wcmp_group_members);
-        if (!update_request_status.ok())
-        {
-            recoverGroupMembers(wcmp_group_entry, wcmp_group_key, created_wcmp_group_members,
-                                removed_wcmp_group_members);
-            return update_request_status;
-        }
+    // Update reference count
+    for (auto& member : old_wcmp->wcmp_group_members) {
+      const std::string& next_hop_key =
+          KeyGenerator::generateNextHopKey(member->next_hop_id);
+      gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+      m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
+      if (!member->watch_port.empty()) {
+        removeMemberFromPortNameToWcmpGroupMemberMap(member);
+      }
     }
-
-    // Create the new member with the smallest weight if member list is nonempty
-    if (reserved_new_member_index != -1)
-    {
-        update_request_status = processWcmpGroupMembersAddition(
-            {wcmp_group_entry->wcmp_group_members[reserved_new_member_index]}, wcmp_group_key,
-            wcmp_group_entry->wcmp_group_oid, created_wcmp_group_members);
-        if (!update_request_status.ok())
-        {
-            recoverGroupMembers(wcmp_group_entry, wcmp_group_key, created_wcmp_group_members,
-                                removed_wcmp_group_members);
-            return update_request_status;
-        }
-    }
-
-    // Remove the old member with the smallest weight if member list is nonempty
-    if (reserved_old_member_index != -1)
-    {
-        update_request_status = processWcmpGroupMembersRemoval(
-            {old_wcmp->wcmp_group_members[reserved_old_member_index]}, wcmp_group_key, removed_wcmp_group_members);
-        if (!update_request_status.ok())
-        {
-            recoverGroupMembers(wcmp_group_entry, wcmp_group_key, created_wcmp_group_members,
-                                removed_wcmp_group_members);
-            return update_request_status;
-        }
-    }
-
-    // Create new group members
-    if (other_new_members.size() != 0)
-    {
-        update_request_status = processWcmpGroupMembersAddition(
-            other_new_members, wcmp_group_key, wcmp_group_entry->wcmp_group_oid, created_wcmp_group_members);
-        if (!update_request_status.ok())
-        {
-            recoverGroupMembers(wcmp_group_entry, wcmp_group_key, created_wcmp_group_members,
-                                removed_wcmp_group_members);
-            return update_request_status;
-        }
+    for (auto& member : wcmp_group_entry->wcmp_group_members) {
+      const std::string& next_hop_key =
+          KeyGenerator::generateNextHopKey(member->next_hop_id);
+      gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+      m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
+      if (!member->watch_port.empty()) {
+        insertMemberInPortNameToWcmpGroupMemberMap(member);
+      }
     }
 
     m_wcmpGroupTable[wcmp_group_entry->wcmp_group_id] = *wcmp_group_entry;
-    return update_request_status;
-}
-
-ReturnCode WcmpManager::removeWcmpGroupMember(const std::shared_ptr<P4WcmpGroupMemberEntry> wcmp_group_member,
-                                              const std::string &wcmp_group_key)
-{
-    SWSS_LOG_ENTER();
-
-    CHECK_ERROR_AND_LOG_AND_RETURN(sai_next_hop_group_api->remove_next_hop_group_member(wcmp_group_member->member_oid),
-                                   "Failed to remove WCMP group member with nexthop id "
-                                       << QuotedVar(wcmp_group_member->next_hop_id));
-    m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-                            getWcmpGroupMemberKey(wcmp_group_key, wcmp_group_member->member_oid));
-    m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
     return ReturnCode();
-}
-
-ReturnCode WcmpManager::processWcmpGroupMembersRemoval(
-    const std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> &members, const std::string &wcmp_group_key,
-    std::vector<std::shared_ptr<P4WcmpGroupMemberEntry>> &removed_wcmp_group_members)
-{
-    SWSS_LOG_ENTER();
-    ReturnCode status;
-    std::vector<sai_status_t> statuses(members.size(), SAI_STATUS_FAILURE);
-    for (size_t i = 0; i < members.size(); ++i)
-    {
-        auto &member = members[i];
-        if (!member->pruned)
-        {
-            gNextHopGroupMemberBulker.remove_entry(&statuses[i], member->member_oid);
-        }
-    }
-    gNextHopGroupMemberBulker.flush();
-    for (size_t i = 0; i < members.size(); ++i)
-    {
-        auto &member = members[i];
-        if (member->pruned)
-        {
-            SWSS_LOG_NOTICE("Removed pruned member %s from group %s", member->next_hop_id.c_str(),
-                            member->wcmp_group_id.c_str());
-            member->pruned = false;
-        }
-        else
-        {
-            if (statuses[i] != SAI_STATUS_SUCCESS)
-            {
-                if (status.ok())
-                {
-                    status = ReturnCode(statuses[i])
-                             << "Failed to delete WCMP group member: " << QuotedVar(member->next_hop_id);
-                }
-                else
-                {
-                    status << "; Failed to delete WCMP group member: " << QuotedVar(member->next_hop_id);
-                }
-                continue;
-            }
-            else
-            {
-                m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-                                        getWcmpGroupMemberKey(wcmp_group_key, member->member_oid));
-                m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
-            }
-        }
-        const std::string &next_hop_key = KeyGenerator::generateNextHopKey(member->next_hop_id);
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
-        m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
-        removeMemberFromPortNameToWcmpGroupMemberMap(member);
-        removed_wcmp_group_members.push_back(member);
-    }
-    return status;
 }
 
 ReturnCode WcmpManager::removeWcmpGroup(const std::string &wcmp_group_id)
@@ -610,113 +350,74 @@ ReturnCode WcmpManager::removeWcmpGroup(const std::string &wcmp_group_id)
         LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
                              << "WCMP group with id " << QuotedVar(wcmp_group_id) << " was not found.");
     }
+
     // Check refcount before deleting group members
-    uint32_t expected_refcount = (uint32_t)wcmp_group->wcmp_group_members.size();
     uint32_t wcmp_group_refcount = 0;
     const auto &wcmp_group_key = KeyGenerator::generateWcmpGroupKey(wcmp_group_id);
     m_p4OidMapper->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key, &wcmp_group_refcount);
-    if (wcmp_group_refcount > expected_refcount)
-    {
-        LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_IN_USE)
-                             << "Failed to remove WCMP group with id " << QuotedVar(wcmp_group_id) << ", as it has "
-                             << wcmp_group_refcount - expected_refcount << " more objects than its group members (size="
-                             << expected_refcount << ") referencing it.");
+    if (wcmp_group_refcount > 0) {
+      LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_IN_USE)
+                           << "Failed to remove WCMP group with id "
+                           << QuotedVar(wcmp_group_id)
+                           << ", non-zero ref count " << wcmp_group_refcount);
     }
-
-    // Delete group members
-    std::vector<std::shared_ptr<p4orch::P4WcmpGroupMemberEntry>> removed_wcmp_group_members;
-    ReturnCode status =
-        processWcmpGroupMembersRemoval(wcmp_group->wcmp_group_members, wcmp_group_key, removed_wcmp_group_members);
 
     // Delete group
-    if (status.ok())
-    {
-        auto sai_status = sai_next_hop_group_api->remove_next_hop_group(wcmp_group->wcmp_group_oid);
-        if (sai_status == SAI_STATUS_SUCCESS)
-        {
-            m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
-            gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
-            m_wcmpGroupTable.erase(wcmp_group->wcmp_group_id);
-            return ReturnCode();
-        }
-        status = ReturnCode(sai_status) << "Failed to delete WCMP group with id "
-                                        << QuotedVar(wcmp_group->wcmp_group_id);
-        SWSS_LOG_ERROR("%s SAI_STATUS: %s", status.message().c_str(), sai_serialize_status(sai_status).c_str());
+    CHECK_ERROR_AND_LOG_AND_RETURN(
+        sai_next_hop_group_api->remove_next_hop_group(
+            wcmp_group->wcmp_group_oid),
+        "Failed to delete WCMP group with id "
+            << QuotedVar(wcmp_group->wcmp_group_id));
+    m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key);
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
+
+    for (auto& member : wcmp_group->wcmp_group_members) {
+      const std::string& next_hop_key =
+          KeyGenerator::generateNextHopKey(member->next_hop_id);
+      gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+      m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
+      if (!member->watch_port.empty()) {
+        removeMemberFromPortNameToWcmpGroupMemberMap(member);
+      }
     }
-    // Recover group members.
-    recoverGroupMembers(wcmp_group, wcmp_group_key, {}, removed_wcmp_group_members);
-    return status;
+
+    m_wcmpGroupTable.erase(wcmp_group->wcmp_group_id);
+    return ReturnCode();
 }
 
-void WcmpManager::pruneNextHops(const std::string &port)
-{
-    SWSS_LOG_ENTER();
+void WcmpManager::updateWatchPort(const std::string& port, bool prune) {
+  SWSS_LOG_ENTER();
 
-    // Get list of WCMP group members associated with the watch_port
-    if (port_name_to_wcmp_group_member_map.find(port) != port_name_to_wcmp_group_member_map.end())
-    {
-        for (const auto &member : port_name_to_wcmp_group_member_map[port])
-        {
-            // Prune a member if it is not already pruned.
-            if (!member->pruned)
-            {
-                const auto &wcmp_group_key = KeyGenerator::generateWcmpGroupKey(member->wcmp_group_id);
-                auto status = removeWcmpGroupMember(member, wcmp_group_key);
-                if (!status.ok())
-                {
-                    std::stringstream msg;
-                    msg << "Failed to prune member " << member->next_hop_id << " from group " << member->wcmp_group_id
-                        << ": " << status.message();
-                    SWSS_RAISE_CRITICAL_STATE(msg.str());
-                    return;
-                }
-                member->pruned = true;
-                SWSS_LOG_NOTICE("Pruned member %s from group %s", member->next_hop_id.c_str(),
-                                member->wcmp_group_id.c_str());
-            }
+  // Get list of WCMP group members associated with the watch_port
+
+  if (port_name_to_wcmp_group_member_map.find(port) !=
+      port_name_to_wcmp_group_member_map.end()) {
+    for (auto& member : port_name_to_wcmp_group_member_map[port]) {
+      if (member->pruned != prune) {
+        auto* wcmp_group = getWcmpGroupEntry(member->wcmp_group_id);
+        if (wcmp_group == nullptr) {
+          SWSS_RAISE_CRITICAL_STATE("Failed to find WCMP group " +
+                                    QuotedVar(member->wcmp_group_id) +
+                                    " in updateWatchPort");
+        } else {
+          const std::string update = prune ? "prune" : "restore";
+          member->pruned = prune;
+          auto status = updateGroup(*wcmp_group);
+          if (!status.ok()) {
+            member->pruned = !member->pruned;
+            SWSS_RAISE_CRITICAL_STATE(
+                "Failed to " + update + " member in group " +
+                QuotedVar(member->wcmp_group_id) +
+                " in updateWatchPort: " + status.message());
+          } else {
+            SWSS_LOG_NOTICE("%s member %s from group %s", update.c_str(),
+                            member->next_hop_id.c_str(),
+                            member->wcmp_group_id.c_str());
+          }
         }
+      }
     }
-}
-
-void WcmpManager::restorePrunedNextHops(const std::string &port)
-{
-    SWSS_LOG_ENTER();
-
-    //  Get list of WCMP group members associated with the watch_port that were
-    //  pruned
-    if (port_name_to_wcmp_group_member_map.find(port) != port_name_to_wcmp_group_member_map.end())
-    {
-        ReturnCode status;
-        for (auto member : port_name_to_wcmp_group_member_map[port])
-        {
-            if (member->pruned)
-            {
-                const auto &wcmp_group_key = KeyGenerator::generateWcmpGroupKey(member->wcmp_group_id);
-                sai_object_id_t wcmp_group_oid = SAI_NULL_OBJECT_ID;
-                if (!m_p4OidMapper->getOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, wcmp_group_key, &wcmp_group_oid))
-                {
-                    status = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                             << "Error during restoring pruned next hop: Failed to get "
-                                "WCMP group OID for group "
-                             << member->wcmp_group_id;
-                    SWSS_LOG_ERROR("%s", status.message().c_str());
-                    SWSS_RAISE_CRITICAL_STATE(status.message());
-                    return;
-                }
-                status = createWcmpGroupMember(member, wcmp_group_oid, wcmp_group_key);
-                if (!status.ok())
-                {
-                    status.prepend("Error during restoring pruned next hop: ");
-                    SWSS_LOG_ERROR("%s", status.message().c_str());
-                    SWSS_RAISE_CRITICAL_STATE(status.message());
-                    return;
-                }
-                member->pruned = false;
-                SWSS_LOG_NOTICE("Restored pruned member %s in group %s", member->next_hop_id.c_str(),
-                                member->wcmp_group_id.c_str());
-            }
-        }
-    }
+  }
 }
 
 bool WcmpManager::getPortOperStatusFromMap(const std::string &port, sai_port_oper_status_t *oper_status)
@@ -967,71 +668,48 @@ std::string WcmpManager::verifyStateCache(const P4WcmpGroupEntry &app_db_entry,
                 << QuotedVar(wcmp_group_entry->wcmp_group_members[i]->wcmp_group_id) << " in wcmp manager.";
             return msg.str();
         }
-        if (!app_db_entry.wcmp_group_members[i]->watch_port.empty() && wcmp_group_entry->wcmp_group_members[i]->pruned)
-        {
-            continue;
-        }
-        err_msg = m_p4OidMapper->verifyOIDMapping(
-            SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER,
-            getWcmpGroupMemberKey(wcmp_group_key, wcmp_group_entry->wcmp_group_members[i]->member_oid),
-            wcmp_group_entry->wcmp_group_members[i]->member_oid);
-        if (!err_msg.empty())
-        {
-            return err_msg;
+        sai_object_id_t nexthop_oid = SAI_NULL_OBJECT_ID;
+        m_p4OidMapper->getOID(
+            SAI_OBJECT_TYPE_NEXT_HOP,
+            KeyGenerator::generateNextHopKey(
+                wcmp_group_entry->wcmp_group_members[i]->next_hop_id),
+            &nexthop_oid);
+        if (wcmp_group_entry->wcmp_group_members[i]->next_hop_oid !=
+            nexthop_oid) {
+          std::stringstream msg;
+          msg << "WCMP group member "
+              << QuotedVar(app_db_entry.wcmp_group_members[i]->next_hop_id)
+              << " has unmatched nexthop OID.";
+          return msg.str();
         }
     }
 
     return "";
 }
 
-std::string WcmpManager::verifyStateAsicDb(const P4WcmpGroupEntry *wcmp_group_entry)
-{
-    swss::DBConnector db("ASIC_DB", 0);
-    swss::Table table(&db, "ASIC_STATE");
+std::string WcmpManager::verifyStateAsicDb(P4WcmpGroupEntry* wcmp_group_entry) {
+  swss::DBConnector db("ASIC_DB", 0);
+  swss::Table table(&db, "ASIC_STATE");
 
-    auto group_attrs = getSaiGroupAttrs(*wcmp_group_entry);
-    std::vector<swss::FieldValueTuple> exp = saimeta::SaiAttributeList::serialize_attr_list(
-        SAI_OBJECT_TYPE_NEXT_HOP_GROUP, (uint32_t)group_attrs.size(), group_attrs.data(), /*countOnly=*/false);
-    std::string key = sai_serialize_object_type(SAI_OBJECT_TYPE_NEXT_HOP_GROUP) + ":" +
-                      sai_serialize_object_id(wcmp_group_entry->wcmp_group_oid);
-    std::vector<swss::FieldValueTuple> values;
-    if (!table.get(key, values))
-    {
-        return std::string("ASIC DB key not found ") + key;
-    }
-    auto group_result = verifyAttrs(values, exp, std::vector<swss::FieldValueTuple>{},
-                                    /*allow_unknown=*/false);
-    if (!group_result.empty())
-    {
-        return group_result;
-    }
-
-    for (const auto &member : wcmp_group_entry->wcmp_group_members)
-    {
-        if (!member->watch_port.empty() && member->pruned)
-        {
-            continue;
-        }
-        auto member_attrs = getSaiMemberAttrs(*member, wcmp_group_entry->wcmp_group_oid);
-        std::vector<swss::FieldValueTuple> exp = saimeta::SaiAttributeList::serialize_attr_list(
-            SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, (uint32_t)member_attrs.size(), member_attrs.data(),
-            /*countOnly=*/false);
-        std::string key = sai_serialize_object_type(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER) + ":" +
-                          sai_serialize_object_id(member->member_oid);
-        std::vector<swss::FieldValueTuple> values;
-        if (!table.get(key, values))
-        {
-            return std::string("ASIC DB key not found ") + key;
-        }
-        auto member_result = verifyAttrs(values, exp, std::vector<swss::FieldValueTuple>{},
-                                         /*allow_unknown=*/false);
-        if (!member_result.empty())
-        {
-            return member_result;
-        }
-    }
-
-    return "";
+  auto group_attrs = prepareSaiGroupAttrs(*wcmp_group_entry);
+  std::vector<swss::FieldValueTuple> exp =
+      saimeta::SaiAttributeList::serialize_attr_list(
+          SAI_OBJECT_TYPE_NEXT_HOP_GROUP, (uint32_t)group_attrs.size(),
+          group_attrs.data(), /*countOnly=*/false);
+  std::string key = sai_serialize_object_type(SAI_OBJECT_TYPE_NEXT_HOP_GROUP) +
+                    ":" +
+                    sai_serialize_object_id(wcmp_group_entry->wcmp_group_oid);
+  std::vector<swss::FieldValueTuple> values;
+  if (!table.get(key, values)) {
+    return std::string("ASIC DB key not found ") + key;
+  }
+  auto group_result =
+      verifyAttrs(values, exp, std::vector<swss::FieldValueTuple>{},
+                  /*allow_unknown=*/false);
+  if (!group_result.empty()) {
+    return group_result;
+  }
+  return "";
 }
 
 } // namespace p4orch

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -110,11 +110,11 @@ ReturnCode WcmpManager::validateWcmpGroupEntry(const P4WcmpGroupEntry &app_db_en
         if (!wcmp_group_member->watch_port.empty())
         {
             Port port;
-            if (!gPortsOrch->getPort(wcmp_group_member->watch_port, port))
+            if (!gPortsOrch->getPort(wcmp_group_member->watch_port, port) ||
+                !gPortsOrch->isFrontPanelPort(port))
             {
-                return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Invalid watch_port field " << wcmp_group_member->watch_port
-                       << ": should be a valid port name.";
+              return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                     << ": should be a valid front panel port name.";
             }
         }
     }

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -250,14 +250,12 @@ ReturnCode WcmpManager::fetchPortOperStatus(const std::string &port_name, sai_po
             SWSS_LOG_ERROR("Failed to get port object for port %s", port_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM);
         }
-        // Get the oper-status of the port from hardware. In case of warm reboot,
-        // this ensures that actual state of the port oper-status is used to
-        // determine whether member associated with watch_port is to be created in
-        // SAI.
-        if (!gPortsOrch->getPortOperStatus(port, *oper_status))
-        {
-            RETURN_INTERNAL_ERROR_AND_RAISE_CRITICAL("Failed to get port oper-status for port " << port.m_alias);
-        }
+        // Get the oper-status of the port from PortsOrch. In case of warm reboot,
+        // this ensures that the oper-status before reboot is used to determine
+        // the watchport status of the member, thereby avoiding any ASIC operations
+        // during reconciliation.
+        *oper_status = port.m_oper_status;
+
         // Update port oper-status in local map
         updatePortOperStatusMap(port.m_alias, *oper_status);
     }
@@ -710,6 +708,23 @@ std::string WcmpManager::verifyStateAsicDb(P4WcmpGroupEntry* wcmp_group_entry) {
     return group_result;
   }
   return "";
+}
+
+void WcmpManager::refreshPortOperStatus() {
+  for (const auto& it : port_oper_status_map) {
+    Port port;
+    if (!gPortsOrch->getPort(it.first, port)) {
+      SWSS_LOG_ERROR("Failed to get port object for port %s",
+                     it.first.c_str());
+      continue;
+    }
+    // Update oper-status in local cache.
+    updatePortOperStatusMap(it.first, port.m_oper_status);
+    // Update watchport to ensure pruning/restoration logic is triggered based
+    // on the updated oper-status.
+    bool prune = port.m_oper_status != SAI_PORT_OPER_STATUS_UP;
+    updateWatchPort(it.first, prune);
+  }
 }
 
 } // namespace p4orch

--- a/orchagent/p4orch/wcmp_manager.h
+++ b/orchagent/p4orch/wcmp_manager.h
@@ -91,6 +91,9 @@ class WcmpManager : public ObjectManagerInterface
     // Inserts into/updates port_oper_status_map
     void updatePortOperStatusMap(const std::string &port, const sai_port_oper_status_t &status);
 
+    // Refreshes port oper-status with the latest values from PortsOrch.
+    void refreshPortOperStatus();
+
   private:
     // Gets the internal cached WCMP group entry by its key.
     // Return nullptr if corresponding WCMP group entry is not cached.

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -231,6 +231,12 @@ const vector<sai_port_attr_t> port_phy_attr_ids =
     SAI_PORT_ATTR_RX_SNR                // Receive Signal-to-Noise Ratio per lane
 };
 
+const vector<sai_port_serdes_attr_t> port_phy_serdes_attr_ids =
+{
+   SAI_PORT_SERDES_ATTR_RX_VGA,          // RX VGA setting values per lane
+   SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST // TX FIR tap values per lane
+};
+
 const vector<sai_port_stat_t> port_stat_ids =
 {
     SAI_PORT_STAT_IF_IN_OCTETS,
@@ -718,6 +724,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         m_portOpErrTable(stateDb, STATE_PORT_OPER_ERR_TABLE_NAME),
         port_stat_manager(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
         port_phy_attr_manager(PORT_PHY_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
+        port_phy_serdes_attr_manager(PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
         gb_port_stat_manager(true,
                 PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
                 PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
@@ -731,6 +738,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         counter_managers({
                 ref(port_stat_manager),
                 ref(port_phy_attr_manager),
+                ref(port_phy_serdes_attr_manager),
                 ref(port_buffer_drop_stat_manager),
                 ref(queue_stat_manager),
                 ref(queue_watermark_manager),
@@ -750,6 +758,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     m_counterSysPortTable = unique_ptr<Table>(
                     new Table(m_counter_db.get(), COUNTERS_SYSTEM_PORT_NAME_MAP));
     m_counterLagTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_LAG_NAME_MAP));
+    m_portSerdesIdToPortIdTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP));
     FieldValueTuple tuple("", "");
     vector<FieldValueTuple> defaultLagFv;
     defaultLagFv.push_back(tuple);
@@ -1082,6 +1091,9 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
     /* Query PORT_PHY_ATTR capabilities */
     queryPortPhyAttrCapabilities();
+
+    /* Query PORT_PHY_SERDES_ATTR capabilities */
+    queryPortPhySerdesAttrCapabilities();
 
     /* Initialize the stats capability in STATE_DB */
     initCounterCapabilities(gSwitchId);
@@ -4067,6 +4079,26 @@ void PortsOrch::registerPort(Port &p)
     fields.push_back(tuple);
     m_counterNameMapUpdater->setCounterNameMap(p.m_alias, p.m_port_id);
 
+    /* Get Port Serdes Id of this port*/
+    sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+    if (p.m_type == Port::Type::PHY) {
+        port_serdes_id = getPortSerdesIdFromPortId(p.m_port_id);
+    }
+
+    /* Add port serdes to port mapping */
+    if (port_serdes_id != SAI_NULL_OBJECT_ID)
+    {
+        // Store in memory map
+        m_portIdToSerdesId[p.m_port_id] = port_serdes_id;
+
+        // Store in COUNTERS_DB
+        FieldValueTuple serdes_tuple(sai_serialize_object_id(port_serdes_id),
+            sai_serialize_object_id(p.m_port_id));
+        vector<FieldValueTuple> serdes_fields;
+        serdes_fields.push_back(serdes_tuple);
+        m_portSerdesIdToPortIdTable->set("", serdes_fields);
+    }
+
     // Install a flex counter for this port to track stats
     auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
     /* Delay installing the counters if they are yet enabled
@@ -4086,16 +4118,33 @@ void PortsOrch::registerPort(Port &p)
     }
     if (flex_counters_orch->getPortPhyAttrCounterState())
     {
-        if (!m_supported_phy_attrs.empty())
+        if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY)
         {
-            if (p.m_type == Port::Type::PHY && verifyPortSupportsAllPhyAttr(p.m_port_id, p.m_alias.c_str()))
+            auto supported_attrs = getPortPhySupportedAttrs(p.m_port_id, p.m_alias.c_str());
+            if (!supported_attrs.empty())
             {
-                auto port_phy_attr_stats = generateCounterStats(m_supported_phy_attrs, sai_serialize_port_attr);
+                auto port_phy_attr_stats = generateCounterStats(supported_attrs, sai_serialize_port_attr);
                 port_phy_attr_manager.setCounterIdList(p.m_port_id,
                         CounterType::PORT_PHY_ATTR, port_phy_attr_stats);
             }
         }
     }
+
+    if (flex_counters_orch->getPortPhySerdesAttrCountersState())
+    {
+        if (!m_supported_phy_serdes_attrs.empty() &&
+            p.m_type == Port::Type::PHY &&
+            port_serdes_id != SAI_NULL_OBJECT_ID)
+        {
+            auto supported_attrs = getPortPhySerdesSupportedAttrs(port_serdes_id, p.m_alias.c_str());
+            if (!supported_attrs.empty())
+            {
+                auto port_attr_serdes_stats = generateCounterStats(supported_attrs, sai_serialize_port_serdes_attr);
+                port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id, CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+            }
+        }
+    }
+
     if (flex_counters_orch->getPortBufferDropCountersState())
     {
         auto port_buffer_drop_stats = generateCounterStats(port_buffer_drop_stat_ids, sai_serialize_port_stat);
@@ -4201,12 +4250,24 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     {
         wred_port_stat_manager.clearCounterIdList(p.m_port_id);
     }
-    if (!m_supported_phy_attrs.empty())
+    if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY)
     {
-        if (p.m_type == Port::Type::PHY && verifyPortSupportsAllPhyAttr(p.m_port_id, p.m_alias.c_str()))
-        {
-            port_phy_attr_manager.clearCounterIdList(p.m_port_id);
-        }
+        port_phy_attr_manager.clearCounterIdList(p.m_port_id);
+    }
+
+    /* Get port serdes id for this port from local cached map */
+    sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+    auto it = m_portIdToSerdesId.find(p.m_port_id);
+    if (it != m_portIdToSerdesId.end())
+    {
+        port_serdes_id = it->second;
+    }
+
+    if (!m_supported_phy_serdes_attrs.empty() &&
+        p.m_type == Port::Type::PHY &&
+        port_serdes_id != SAI_NULL_OBJECT_ID)
+    {
+        port_phy_serdes_attr_manager.clearCounterIdList(port_serdes_id);
     }
 
     /* remove port name map from counter table */
@@ -9046,57 +9107,67 @@ void PortsOrch::queryPortPhyAttrCapabilities()
     }
 }
 
-bool PortsOrch::verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char* port_name)
+std::vector<sai_port_attr_t> PortsOrch::getPortPhySupportedAttrs(sai_object_id_t port_id, const char* port_name)
 {
-    // Verify port supports ALL SERDES attributes
-    // Query with count=0 to check if attribute is supported (expect BUFFER_OVERFLOW)
+    std::vector<sai_port_attr_t> supported_attrs;
 
-    // Check RX_SIGNAL_DETECT
-    sai_attribute_t port_attr;
-    port_attr.id = SAI_PORT_ATTR_RX_SIGNAL_DETECT;
-    port_attr.value.portlanelatchstatuslist.count = 0;
-    port_attr.value.portlanelatchstatuslist.list = nullptr;
+    // Lambda function to check attribute support and handle logging
+    auto checkPortPhyAttrSupport = [&](sai_attribute_t& port_attr, const char* attr_name) {
+        sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
+        if (status == SAI_STATUS_BUFFER_OVERFLOW)
+        {
+            supported_attrs.push_back(static_cast<sai_port_attr_t>(port_attr.id));
+            SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports %s attribute",
+                           port_name, attr_name);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support %s attribute (status=%d)",
+                          port_name, attr_name, status);
+        }
+    };
 
-    sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
+    // Iterate through platform-supported attributes and check if this port supports them
+    for (const auto& attr_id : m_supported_phy_attrs)
     {
-        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support RX_SIGNAL_DETECT attribute (status=%d)",
-                      port_name, status);
-        return false;
+        sai_attribute_t port_attr;
+        switch (attr_id)
+        {
+            case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+            {
+                port_attr.id = SAI_PORT_ATTR_RX_SIGNAL_DETECT;
+                port_attr.value.portlanelatchstatuslist.count = 0;
+                port_attr.value.portlanelatchstatuslist.list = nullptr;
+                checkPortPhyAttrSupport(port_attr, "SAI_PORT_ATTR_RX_SIGNAL_DETECT");
+                break;
+            }
+
+            case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+            {
+                port_attr.id = SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK;
+                port_attr.value.portlanelatchstatuslist.count = 0;
+                port_attr.value.portlanelatchstatuslist.list = nullptr;
+                checkPortPhyAttrSupport(port_attr, "SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK");
+                break;
+            }
+
+            case SAI_PORT_ATTR_RX_SNR:
+            {
+                port_attr.id = SAI_PORT_ATTR_RX_SNR;
+                port_attr.value.portsnrlist.count = 0;
+                port_attr.value.portsnrlist.list = nullptr;
+                checkPortPhyAttrSupport(port_attr, "SAI_PORT_ATTR_RX_SNR");
+                break;
+            }
+
+            default:
+                SWSS_LOG_WARN("PORT_PHY_ATTR: Unknown attribute %d in m_supported_phy_attrs for port %s",
+                    attr_id, port_name);
+                break;
+        }
     }
-    SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports RX_SIGNAL_DETECT attribute (count=%d)",
-                   port_name, port_attr.value.portlanelatchstatuslist.count);
 
-    // Check FEC_ALIGNMENT_LOCK
-    port_attr.id = SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK;
-    port_attr.value.portlanelatchstatuslist.count = 0;
-    port_attr.value.portlanelatchstatuslist.list = nullptr;
-
-    status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support FEC_ALIGNMENT_LOCK attribute (status=%d)",
-                      port_name, status);
-        return false;
-    }
-    SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports FEC_ALIGNMENT_LOCK attribute (count=%d)",
-                   port_name, port_attr.value.portlanelatchstatuslist.count);
-
-    // Check RX_SNR
-    port_attr.id = SAI_PORT_ATTR_RX_SNR;
-    port_attr.value.portsnrlist.count = 0;
-    port_attr.value.portsnrlist.list = nullptr;
-
-    status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support RX_SNR attribute (status=%d)",
-                      port_name, status);
-        return false;
-    }
-    SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports RX_SNR attribute (count=%d)",
-                   port_name, port_attr.value.portsnrlist.count);
-    return true;
+    return supported_attrs;
 }
 
 void PortsOrch::generatePortPhyAttrCounterMap()
@@ -9107,17 +9178,20 @@ void PortsOrch::generatePortPhyAttrCounterMap()
         return;
     }
 
-    auto port_phy_attr_stats = generateCounterStats(m_supported_phy_attrs, sai_serialize_port_attr);
-
     for (const auto& it: m_portList)
     {
-        if (it.second.m_type == Port::Type::PHY && verifyPortSupportsAllPhyAttr(it.second.m_port_id, it.second.m_alias.c_str()))
+        if (it.second.m_type == Port::Type::PHY)
         {
-            SWSS_LOG_DEBUG("PORT_PHY_ATTR: Setting counter ID list for port %s",
-                          it.second.m_alias.c_str());
+            auto supported_attrs = getPortPhySupportedAttrs(it.second.m_port_id, it.second.m_alias.c_str());
+            if (!supported_attrs.empty())
+            {
+                auto port_phy_attr_stats = generateCounterStats(supported_attrs, sai_serialize_port_attr);
+                SWSS_LOG_DEBUG("PORT_PHY_ATTR: Setting counter ID list for port %s",
+                              it.second.m_alias.c_str());
 
-            port_phy_attr_manager.setCounterIdList(it.second.m_port_id,
-                    CounterType::PORT_PHY_ATTR, port_phy_attr_stats);
+                port_phy_attr_manager.setCounterIdList(it.second.m_port_id,
+                        CounterType::PORT_PHY_ATTR, port_phy_attr_stats);
+            }
         }
     }
 }
@@ -9141,6 +9215,183 @@ void PortsOrch::clearPortPhyAttrCounterMap()
 const std::vector<sai_port_attr_t>& PortsOrch::getPortPhyAttrIds() const
 {
     return port_phy_attr_ids;
+}
+
+sai_object_id_t PortsOrch::getPortSerdesIdFromPortId(sai_object_id_t port_id)
+{
+    sai_attribute_t port_attr;
+
+    port_attr.id = SAI_PORT_ATTR_PORT_SERDES_ID;
+    sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get port serdes ID for port 0x%" PRIx64 " (status=%d)", port_id, status);
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    return port_attr.value.oid;
+}
+
+void PortsOrch::queryPortPhySerdesAttrCapabilities()
+{
+    for (const auto& attr_id : port_phy_serdes_attr_ids)
+    {
+        sai_attr_capability_t capability;
+
+        sai_status_t status = sai_query_attribute_capability(
+            gSwitchId,
+            SAI_OBJECT_TYPE_PORT_SERDES,
+            attr_id,
+            &capability
+        );
+
+        auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT_SERDES, attr_id);
+        std::string attr_id_str = std::to_string(attr_id);
+        const char* attr_name = meta ? meta->attridname : attr_id_str.c_str();
+
+        if (status == SAI_STATUS_SUCCESS && capability.get_implemented)
+        {
+            m_supported_phy_serdes_attrs.push_back(attr_id);
+            SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: Attribute %s is SUPPORTED for GET",
+                            attr_name);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: Attribute %s is NOT supported (status=%d, get_implemented=%d)",
+                            attr_name, status, capability.get_implemented);
+        }
+    }
+}
+
+std::vector<sai_port_serdes_attr_t> PortsOrch::getPortPhySerdesSupportedAttrs(sai_object_id_t port_serdes_id, const char* port_name)
+{
+    std::vector<sai_port_serdes_attr_t> supported_attrs;
+
+    // Lambda function to check attribute support and handle logging
+    auto checkPortPhySerdesAttrSupport = [&](sai_attribute_t& test_attr, const char* attr_name) {
+        sai_status_t status = sai_port_api->get_port_serdes_attribute(port_serdes_id, 1, &test_attr);
+        if (status == SAI_STATUS_BUFFER_OVERFLOW)
+        {
+            supported_attrs.push_back(static_cast<sai_port_serdes_attr_t>(test_attr.id));
+            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Port %s supports %s attribute",
+                port_name, attr_name);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: Port %s does not support %s attribute (status=%d)",
+                port_name, attr_name, status);
+        }
+    };
+
+    // Iterate through platform-supported attributes and check if this port supports them
+    for (const auto& attr_id : m_supported_phy_serdes_attrs)
+    {
+        sai_attribute_t test_attr;
+        switch (attr_id)
+        {
+            case SAI_PORT_SERDES_ATTR_RX_VGA:
+            {
+                test_attr.id = SAI_PORT_SERDES_ATTR_RX_VGA;
+                test_attr.value.u32list.count = 0;
+                test_attr.value.u32list.list = nullptr;
+                checkPortPhySerdesAttrSupport(test_attr, "SAI_PORT_SERDES_ATTR_RX_VGA");
+                break;
+            }
+
+            case SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST:
+            {
+                test_attr.id = SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST;
+                test_attr.value.portserdestaps.count = 0;
+                test_attr.value.portserdestaps.list = nullptr;
+                checkPortPhySerdesAttrSupport(test_attr, "SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST");
+                break;
+            }
+
+            default:
+                SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: Unknown attribute %d in m_supported_phy_serdes_attrs for port %s",
+                    attr_id, port_name);
+                break;
+        }
+    }
+
+    return supported_attrs;
+  }
+
+void PortsOrch::generatePortPhySerdesAttrCounterMap()
+{
+    if (m_supported_phy_serdes_attrs.empty())
+    {
+        SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: No PORT SERDES attributes supported on this platform");
+        return;
+    }
+
+    for (const auto& it: m_portList)
+    {
+        if (it.second.m_type == Port::Type::PHY)
+        {
+            const char *port_name = it.second.m_alias.c_str();
+            sai_object_id_t port_id = it.second.m_port_id;
+            sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+
+            // Get the port_serdes_id from local map.
+            auto iter = m_portIdToSerdesId.find(port_id);
+            if (iter != m_portIdToSerdesId.end())
+            {
+               port_serdes_id = iter->second;
+            }
+
+            if (port_serdes_id == SAI_NULL_OBJECT_ID)
+            {
+                SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s has no serdes object", port_name);
+                continue;
+            }
+
+            auto supported_attrs = getPortPhySerdesSupportedAttrs(port_serdes_id, port_name);
+            if (!supported_attrs.empty())
+            {
+                auto port_serdes_attr_stats = generateCounterStats(supported_attrs, sai_serialize_port_serdes_attr);
+                SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Setting counter ID list for port %s", port_name);
+                port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id,
+                    CounterType::PORT_PHY_SERDES_ATTR, port_serdes_attr_stats);
+            }
+         }
+    }
+}
+
+void PortsOrch::clearPortPhySerdesAttrCounterMap()
+{
+    for (const auto& it: m_portList)
+    {
+        // Clear counter stats only for PHY ports that were previously configured
+        if (it.second.m_type != Port::Type::PHY)
+        {
+            continue;
+        }
+
+        sai_object_id_t port_id = it.second.m_port_id;
+        sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+
+        // Get the port_serdes_id from local map.
+        auto iter = m_portIdToSerdesId.find(port_id);
+        if (iter != m_portIdToSerdesId.end())
+        {
+            port_serdes_id = iter->second;
+        }
+
+        if (port_serdes_id == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s has no serdes object", it.second.m_alias.c_str());
+            continue;
+        }
+
+        SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Clearing counter ID list for port %s", it.second.m_alias.c_str());
+        port_phy_serdes_attr_manager.clearCounterIdList(port_serdes_id);
+    }
+}
+
+const std::vector<sai_port_serdes_attr_t>& PortsOrch::getPortPhySerdesAttrIds() const
+{
+    return port_phy_serdes_attr_ids;
 }
 
 /****
@@ -9806,6 +10057,7 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
     sai_attribute_t port_serdes_attr;
     sai_status_t status;
     sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+    auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
 
     port_attr.id = SAI_PORT_ATTR_PORT_SERDES_ID;
     status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
@@ -9831,6 +10083,24 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
             if (handle_status != task_success)
             {
                 return parseHandleSaiStatusFailure(handle_status);
+            }
+        }
+        else
+        {
+            // Remove old mapping from memory map
+            m_portIdToSerdesId.erase(port_id);
+
+            // Remove old mapping from COUNTERS_DB
+            m_portSerdesIdToPortIdTable->hdel("", sai_serialize_object_id(port_attr.value.oid));
+            SWSS_LOG_INFO("Removed old COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP entry: serdes_id:0x%" PRIx64,
+                         port_attr.value.oid);
+
+            //clear the phy port serdes countersIDList
+            Port p;
+            if (getPort(port_id, p) && p.m_type == Port::Type::PHY &&
+                flex_counters_orch->getPortPhySerdesAttrCountersState())
+            {
+                port_phy_serdes_attr_manager.clearCounterIdList(port_attr.value.oid);
             }
         }
     }
@@ -9866,6 +10136,31 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
         }
     }
     SWSS_LOG_NOTICE("Created port serdes object 0x%" PRIx64 " for port 0x%" PRIx64, port_serdes_id, port_id);
+
+    // Add new mapping to memory map
+    m_portIdToSerdesId[port_id] = port_serdes_id;
+
+    // Add new mapping to COUNTERS_DB
+    FieldValueTuple serdes_tuple(sai_serialize_object_id(port_serdes_id), sai_serialize_object_id(port_id));
+    vector<FieldValueTuple> serdes_fields;
+    serdes_fields.push_back(serdes_tuple);
+    m_portSerdesIdToPortIdTable->set("", serdes_fields);
+    SWSS_LOG_DEBUG("Added COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP: serdes_id:0x%" PRIx64 " -> port_id:0x%" PRIx64, port_serdes_id, port_id);
+
+    // update port-serdes-id counterIdList if applicable.
+    Port p;
+    if (flex_counters_orch->getPortPhySerdesAttrCountersState() &&
+        !m_supported_phy_serdes_attrs.empty() &&
+        getPort(port_id, p) && p.m_type == Port::Type::PHY)
+    {
+        auto supported_attrs = getPortPhySerdesSupportedAttrs(port_serdes_id, p.m_alias.c_str());
+        if (!supported_attrs.empty())
+        {
+            auto port_attr_serdes_stats = generateCounterStats(supported_attrs, sai_serialize_port_serdes_attr);
+            port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id,
+                    CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+        }
+    }
 
     return true;
 }
@@ -9927,6 +10222,12 @@ void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
             handleSaiRemoveStatus(SAI_API_PORT, status);
             return;
         }
+        // Remove mapping from memory map
+        m_portIdToSerdesId.erase(port_id);
+        // Remove mapping from COUNTERS_DB
+        m_portSerdesIdToPortIdTable->hdel("", sai_serialize_object_id(port_attr.value.oid));
+        SWSS_LOG_INFO("Removed COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP entry: serdes_id:0x%" PRIx64 " -> port_id:0x%" PRIx64,
+                     port_attr.value.oid, port_id);
     }
     SWSS_LOG_NOTICE("Removed port serdes object 0x%" PRIx64 " for port 0x%" PRIx64, port_serdes_id, port_id);
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4395,6 +4395,64 @@ void PortsOrch::doSendToIngressPortTask(Consumer &consumer)
     }
 }
 
+// Helper function to program serdes with admin state management
+bool PortsOrch::programSerdes(
+    Port &port,
+    sai_object_id_t port_id,
+    sai_object_id_t switch_id,
+    PortSerdesAttrMap_t &serdes_attr)
+{
+    // Validate port_id and determine serdes type
+    const char* serdes_type_name;
+    if (port_id == port.m_port_id)
+    {
+        serdes_type_name = "ASIC";
+    }
+    else if (port_id == port.m_line_side_id)
+    {
+        serdes_type_name = "gearbox line-side";
+    }
+    else if (port_id == port.m_system_side_id)
+    {
+        serdes_type_name = "gearbox system-side";
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Invalid port_id 0x%" PRIx64 " does not belong to port %s "
+                      "(port_id: 0x%" PRIx64 ", line_side_id: 0x%" PRIx64 ", system_side_id: 0x%" PRIx64 ")",
+                      port_id, port.m_alias.c_str(),
+                      port.m_port_id, port.m_line_side_id, port.m_system_side_id);
+        return false;
+    }
+
+    if (port.m_admin_state_up)
+    {
+        /* Bring port down before applying serdes attribute */
+        if (!setPortAdminStatus(port, false))
+        {
+            SWSS_LOG_ERROR("Failed to set port %s admin status DOWN to set %s serdes attr",
+                          port.m_alias.c_str(), serdes_type_name);
+            return false;
+        }
+
+        port.m_admin_state_up = false;
+        m_portList[port.m_alias] = port;
+    }
+
+    if (setPortSerdesAttribute(port_id, switch_id, serdes_attr))
+    {
+        SWSS_LOG_NOTICE("Successfully set %s serdes tunings for port %s",
+                       serdes_type_name, port.m_alias.c_str());
+        return true;
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Failed to set %s serdes tunings for port %s",
+                      serdes_type_name, port.m_alias.c_str());
+        return false;
+    }
+}
+
 void PortsOrch::doPortTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -5275,32 +5333,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     }
                     else
                     {
-                        if (p.m_admin_state_up)
+                        if (!programSerdes(p, p.m_port_id, gSwitchId, serdes_attr))
                         {
-                                /* Bring port down before applying serdes attribute*/
-                                if (!setPortAdminStatus(p, false))
-                                {
-                                    SWSS_LOG_ERROR("Failed to set port %s admin status DOWN to set serdes attr", p.m_alias.c_str());
-                                    it++;
-                                    continue;
-                                }
-
-                                p.m_admin_state_up = false;
-                                m_portList[p.m_alias] = p;
-                        }
-
-                        if (setPortSerdesAttribute(p.m_port_id, gSwitchId, serdes_attr))
-                        {
-                            SWSS_LOG_NOTICE("Set port %s SI settings is successful", p.m_alias.c_str());
-                            p.m_serdes_attrs = serdes_attr;
-                            m_portList[p.m_alias] = p;
-                        }
-                        else
-                        {
-                            SWSS_LOG_ERROR("Failed to set port %s SI settings", p.m_alias.c_str());
                             it++;
                             continue;
                         }
+                        p.m_serdes_attrs = serdes_attr;
+                        m_portList[p.m_alias] = p;
                     }
                 }
                 if (pCfg.media_type.is_set)
@@ -5321,27 +5360,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (p.m_line_side_id && !line_serdes_attr.empty())
                 {
-                    if (p.m_admin_state_up)
+                    if (!programSerdes(p, p.m_line_side_id, p.m_switch_id, line_serdes_attr))
                     {
-                            /* Bring port down before applying serdes attribute*/
-                            if (!setPortAdminStatus(p, false))
-                            {
-                                SWSS_LOG_ERROR("Failed to set port %s admin status DOWN to set gb line serdes attr", p.m_alias.c_str());
-                                it++;
-                                continue;
-                            }
-
-                            p.m_admin_state_up = false;
-                            m_portList[p.m_alias] = p;
-                    }
-
-                    if (setPortSerdesAttribute(p.m_line_side_id, p.m_switch_id, line_serdes_attr))
-                    {
-                        SWSS_LOG_NOTICE("Successfully set line-side gearbox tunings for port %s", p.m_alias.c_str());
-                    }
-                    else
-                    {
-                        SWSS_LOG_ERROR("Failed to set line-side gearbox tunings for port %s", p.m_alias.c_str());
                         it++;
                         continue;
                     }
@@ -5349,27 +5369,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (p.m_system_side_id && !system_serdes_attr.empty())
                 {
-                    if (p.m_admin_state_up)
+                    if (!programSerdes(p, p.m_system_side_id, p.m_switch_id, system_serdes_attr))
                     {
-                            /* Bring port down before applying serdes attribute*/
-                            if (!setPortAdminStatus(p, false))
-                            {
-                                SWSS_LOG_ERROR("Failed to set port %s admin status DOWN to set gb system serdes attr", p.m_alias.c_str());
-                                it++;
-                                continue;
-                            }
-
-                            p.m_admin_state_up = false;
-                            m_portList[p.m_alias] = p;
-                    }
-
-                    if (setPortSerdesAttribute(p.m_system_side_id, p.m_switch_id, system_serdes_attr))
-                    {
-                        SWSS_LOG_NOTICE("Successfully set system-side gearbox tunings for port %s", p.m_alias.c_str());
-                    }
-                    else
-                    {
-                        SWSS_LOG_ERROR("Failed to set system-side gearbox tunings for port %s", p.m_alias.c_str());
                         it++;
                         continue;
                     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1790,6 +1790,11 @@ bool PortsOrch::getPort(sai_object_id_t id, Port &port)
     return false;
 }
 
+bool PortsOrch::isFrontPanelPort(Port& port)
+{
+    return port.m_type == Port::PHY;
+}
+
 void PortsOrch::increasePortRefCount(const string &alias)
 {
     assert (m_port_ref_count.find(alias) != m_port_ref_count.end());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -35,6 +35,7 @@
 #include "countercheckorch.h"
 #include "notifier.h"
 #include "fdborch.h"
+#include "p4orch/p4orch.h"
 #include "switchorch.h"
 #include "stringutility.h"
 #include "subscriberstatetable.h"
@@ -60,6 +61,7 @@ extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
 extern BufferOrch *gBufferOrch;
 extern FdbOrch *gFdbOrch;
+extern P4Orch *gP4Orch;
 extern SwitchOrch *gSwitchOrch;
 extern StpOrch *gStpOrch;
 extern Directory<Orch*> gDirectory;
@@ -5225,7 +5227,10 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         {
                             gIntfsOrch->setRouterIntfsMtu(p);
                         }
-
+                        if (gP4Orch)
+                        {
+                            gP4Orch->setRouterIntfsMtu(p.m_alias, p.m_mtu);
+                        }
                         // Sub interfaces inherit parent physical port mtu
                         updateChildPortsMtu(p, pCfg.mtu.value);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -560,6 +560,9 @@ private:
 
     void removePortSerdesAttribute(sai_object_id_t port_id);
 
+    bool programSerdes(Port &port, sai_object_id_t port_id, sai_object_id_t switch_id,
+                       std::map<sai_port_serdes_attr_t, SerdesValue> &serdes_attr);
+
     bool getSaiAclBindPointType(Port::Type                type,
                                 sai_acl_bind_point_type_t &sai_acl_bind_type);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -293,6 +293,7 @@ public:
     void setMACsecEnabledState(sai_object_id_t port_id, bool enabled);
     bool isMACsecPort(sai_object_id_t port_id) const;
     vector<sai_object_id_t> getPortVoQIds(Port& port);
+    bool isFrontPanelPort(Port& port);
 
     bool setPortPtIntfId(const Port& port, sai_uint16_t intf_id);
     bool setPortPtTimestampTemplate(const Port& port, sai_port_path_tracing_timestamp_type_t ts_type);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -30,6 +30,7 @@
 #define PORT_RATE_COUNTER_FLEX_COUNTER_GROUP "PORT_RATE_COUNTER"
 #define PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP "PORT_BUFFER_DROP_STAT"
 #define PORT_PHY_ATTR_FLEX_COUNTER_GROUP "PORT_PHY_ATTR"
+#define PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP "PORT_PHY_SERDES_ATTR"
 #define QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_STAT_COUNTER"
 #define QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_WATERMARK_STAT_COUNTER"
 #define PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_WATERMARK_STAT_COUNTER"
@@ -142,6 +143,11 @@ namespace portphyattr_test
 class PortAttrTest;
 } // namespace portphyattr_test
 
+namespace portphyserdesattr_test
+{
+class PortSerdesAttrTest;
+} // namespace portphyserdesattr_test
+
 class PortsOrch : public Orch, public Subject
 {
 public:
@@ -230,7 +236,14 @@ public:
     void clearPortPhyAttrCounterMap();
     const std::vector<sai_port_attr_t>& getPortPhyAttrIds() const;
     void queryPortPhyAttrCapabilities();
-    bool verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char* port_name);
+    std::vector<sai_port_attr_t> getPortPhySupportedAttrs(sai_object_id_t port_id, const char* port_name);
+
+    sai_object_id_t getPortSerdesIdFromPortId(sai_object_id_t port_id);
+    void generatePortPhySerdesAttrCounterMap();
+    void clearPortPhySerdesAttrCounterMap();
+    const std::vector<sai_port_serdes_attr_t>& getPortPhySerdesAttrIds() const;
+    void queryPortPhySerdesAttrCapabilities();
+    std::vector<sai_port_serdes_attr_t> getPortPhySerdesSupportedAttrs(sai_object_id_t port_serdes_id, const char* port_name);
 
     void generateWredPortCounterMap();
     void generateWredQueueCounterMap();
@@ -288,6 +301,7 @@ private:
     unique_ptr<CounterNameMapUpdater> m_counterNameMapUpdater;
     unique_ptr<Table> m_counterSysPortTable;
     unique_ptr<Table> m_counterLagTable;
+    unique_ptr<Table> m_portSerdesIdToPortIdTable;
     unique_ptr<Table> m_portTable;
     unique_ptr<Table> m_sendToIngressPortTable;
     unique_ptr<Table> m_systemPortTable;
@@ -316,6 +330,7 @@ private:
 
     FlexCounterTaggedCachedManager<void> port_stat_manager;
     FlexCounterTaggedCachedManager<void> port_phy_attr_manager;
+    FlexCounterTaggedCachedManager<void> port_phy_serdes_attr_manager;
     FlexCounterTaggedCachedManager<void> port_buffer_drop_stat_manager;
     FlexCounterTaggedCachedManager<sai_queue_type_t> queue_stat_manager;
     FlexCounterTaggedCachedManager<sai_queue_type_t> queue_watermark_manager;
@@ -334,6 +349,9 @@ private:
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
     // Supported FEC modes on the system side.
     std::map<sai_object_id_t, PortFecModeCapability_t> m_portSupportedFecModes;
+
+    // Port ID to Port Serdes ID mapping
+    std::map<sai_object_id_t, sai_object_id_t> m_portIdToSerdesId;
 
     bool m_initDone = false;
     bool m_isSendToIngressPortConfigured = false;
@@ -523,6 +541,8 @@ private:
 
     std::vector<sai_port_attr_t> m_supported_phy_attrs;
 
+    std::vector<sai_port_serdes_attr_t> m_supported_phy_serdes_attrs;
+
     bool isAutoNegEnabled(sai_object_id_t id);
     task_process_status setPortAutoNeg(Port &port, bool autoneg);
     task_process_status setPortUnreliableLOS(Port &port, bool enabled);
@@ -640,5 +660,6 @@ private:
 
     // Friend declaration for unit tests
     friend class portphyattr_test::PortAttrTest;
+    friend class portphyserdesattr_test::PortSerdesAttrTest;
 };
 #endif /* SWSS_PORTSORCH_H */

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -29,7 +29,11 @@ using namespace swss;
 #define STR(s) _STR(s)
 
 #define CONTEXT_CFG_FILE "/usr/share/sonic/hwsku/context_config.json"
+#if defined(__arm__)
+#define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT ((480*1000)*2)
+#else
 #define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT (480*1000)
+#endif
 
 // hwinfo = "INTERFACE_NAME/PHY ID", mii_ioctl_data->phy_id is a __u16
 #define HWINFO_MAX_SIZE IFNAMSIZ + 1 + 5

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1186,9 +1186,12 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
         if (custom_monitor_ep_updated)
         {
-            auto it_route =  syncd_tunnel_routes_[vnet].find(ipPrefix);
-            getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
-            getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
+            auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+            if (it_route != syncd_tunnel_routes_[vnet].end())
+            {
+                getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
+                getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
+            }
         }
 
         sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;

--- a/run-gtest-suite.py
+++ b/run-gtest-suite.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+from lxml import etree
+import sys
+
+
+def str2bool(value):
+    if isinstance(value, bool):
+        return value
+    if value == "yes":
+        return True
+    if value == "no":
+        return False
+    return argparse.ArgumentTypeError(f"Invalid boolean value: {value}")
+
+def main():
+    parser = argparse.ArgumentParser(prog='run-gtest-suite')
+    parser.add_argument('--test-name', type=str, required=True, help='The name of the test')
+    parser.add_argument('--log-file', type=argparse.FileType('w'), required=True, help='The log file created by the test binary')
+    parser.add_argument('--trs-file', type=argparse.FileType('w'), required=True, help='The trs file created by this script')
+    parser.add_argument('--color-tests', type=str2bool, default=False, help='Whether to produce color output or not')
+    parser.add_argument('--collect-skipped-logs', type=str2bool, default=False, help='Whether to include logs of skipped tests (unused)')
+    parser.add_argument('--expect-failure', type=str2bool, default=False, help='Unused')
+    parser.add_argument('--enable-hard-errors', type=str2bool, default=False, help='Unused')
+    parser.add_argument('test_binary', nargs='+')
+    args = parser.parse_args()
+
+    test_args = [f"--gtest_output=xml:{args.test_name}_tr.xml"]
+    if args.color_tests:
+        test_args.append("--gtest_color=yes")
+    else:
+        test_args.append("--gtest_color=no")
+
+    test_process = subprocess.run(args.test_binary + test_args, stdin=subprocess.DEVNULL, stdout=args.log_file, stderr=subprocess.STDOUT)
+
+    junit_xml = etree.parse(f"{args.test_name}_tr.xml")
+    junit_xml_root = junit_xml.getroot()
+    # This code matches how gtest structures the results in its junit output format.
+    for testsuite in junit_xml_root:
+        testsuite_name = testsuite.get("name")
+        for testcase in testsuite:
+            testcase_name = testcase.get("name")
+            was_skipped = testcase.get("result") == "suppressed"
+            has_failed = len(list(testcase)) > 0
+            result = "SKIP" if was_skipped else "FAIL" if has_failed else "PASS"
+            print(f":test-result: {result} {testsuite_name}:{testcase_name}", file=args.trs_file)
+
+    sys.exit(test_process.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/teamsyncd/Makefile.am
+++ b/teamsyncd/Makefile.am
@@ -12,7 +12,7 @@ teamsyncd_SOURCES = teamsyncd.cpp teamsync.cpp
 
 teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-teamsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
+teamsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam -lteamdctl
 
 if GCOV_ENABLED
 teamsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,3 +26,5 @@ tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAG
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I../orchagent
 tests_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
         -lswsscommon -lswsscommon -lgtest -lgtest_main
+
+LOG_DRIVER = $(top_srcdir)/run-gtest-suite.py

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -77,6 +77,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 stporch_ut.cpp \
                 flexcounter_ut.cpp \
                 portphyattr_ut.cpp \
+		portphyserdesattr_ut.cpp \
                 counternameupdater_ut.cpp \
                 hftelprofile_ut.cpp \
                 mock_orch_test.cpp \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -333,9 +333,11 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
 tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
-tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
+tests_nbrmgrd_LDFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+
+
 tests_teamsyncd_SOURCES = teamsync_ut.cpp \
                           $(top_srcdir)/teamsyncd/teamsync.cpp
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd
+TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
 LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
 
@@ -332,6 +332,14 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
 tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
-tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex
+tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+tests_teamsyncd_SOURCES = teamsync_ut.cpp \
+                          $(top_srcdir)/teamsyncd/teamsync.cpp
+
+tests_teamsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/teamsyncd
+tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teamsyncd_INCLUDES)
+tests_teamsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 \
+        -lswsscommon -lgtest -lgtest_main -lpthread -lteam -lteamdctl

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -322,3 +322,5 @@ tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTES
 tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teamsyncd_INCLUDES)
 tests_teamsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 \
         -lswsscommon -lgtest -lgtest_main -lpthread -lteam -lteamdctl
+
+LOG_DRIVER = $(top_srcdir)/run-gtest-suite.py

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -12,9 +12,6 @@ CFLAGS_SAI = -I /usr/include/sai
 TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
 noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_teamsyncd
-
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_teamsyncd
 
 LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -325,6 +325,7 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
                          mock_orchagent_main.cpp \
                          mock_dbconnector.cpp \
                          mock_table.cpp \
+                         mock_consumerstatetable.cpp \
                          mock_hiredis.cpp \
                          fake_response_publisher.cpp \
                          mock_redisreply.cpp \
@@ -333,7 +334,7 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
 tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
-tests_nbrmgrd_LDFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
+tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher
+TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd
 
 LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
 
@@ -312,3 +312,26 @@ tests_response_publisher_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CF
 tests_response_publisher_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_response_publisher_INCLUDES)
 tests_response_publisher_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread
+
+## nbrmgrd unit tests
+
+tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
+                         $(top_srcdir)/cfgmgr/nbrmgr.cpp \
+                         $(top_srcdir)/lib/subintf.cpp \
+                         $(top_srcdir)/lib/recorder.cpp \
+                         $(top_srcdir)/orchagent/orch.cpp \
+                         $(top_srcdir)/orchagent/request_parser.cpp \
+                         mock_orchagent_main.cpp \
+                         mock_dbconnector.cpp \
+                         mock_table.cpp \
+                         mock_hiredis.cpp \
+                         fake_response_publisher.cpp \
+                         mock_redisreply.cpp \
+                         common/mock_shell_command.cpp
+
+tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
+tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
+tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex
+tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -78,6 +78,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 flexcounter_ut.cpp \
                 portphyattr_ut.cpp \
                 counternameupdater_ut.cpp \
+                hftelprofile_ut.cpp \
                 mock_orch_test.cpp \
                 mock_dash_orch_test.cpp \
                 zmq_orch_ut.cpp \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher
+TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_teamsyncd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_teamsyncd
 
 LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
 
@@ -312,3 +312,12 @@ tests_response_publisher_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CF
 tests_response_publisher_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_response_publisher_INCLUDES)
 tests_response_publisher_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread
+
+tests_teamsyncd_SOURCES = teamsync_ut.cpp \
+                          $(top_srcdir)/teamsyncd/teamsync.cpp
+
+tests_teamsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/teamsyncd
+tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teamsyncd_INCLUDES)
+tests_teamsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 \
+        -lswsscommon -lgtest -lgtest_main -lpthread -lteam -lteamdctl

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -52,13 +52,32 @@ namespace dashhaorch_ut
     class DashHaOrchTestable : public DashHaOrch
     {
     public:
+        DashHaOrchTestable(swss::DBConnector* db, const std::vector<std::string>& tableNames,
+                           DashOrch* dash_orch, BfdOrch* bfd_orch,
+                           swss::DBConnector* app_state_db, swss::ZmqServer* zmqServer)
+            : DashHaOrch(db, tableNames, dash_orch, bfd_orch, app_state_db, zmqServer) {}
         void doTask(swss::NotificationConsumer &consumer) { DashHaOrch::doTask(consumer); }
+    };
+
+    class DashHaOrchAdminStateUnsupported : public DashHaOrchTestable
+    {
+    public:
+        DashHaOrchAdminStateUnsupported(swss::DBConnector* db, const std::vector<std::string>& tableNames,
+                                        DashOrch* dash_orch, BfdOrch* bfd_orch,
+                                        swss::DBConnector* app_state_db, swss::ZmqServer* zmqServer)
+            : DashHaOrchTestable(db, tableNames, dash_orch, bfd_orch, app_state_db, zmqServer) {}
+        bool isHaScopeAdminStateAttrSupported() override { return false; }
     };
 
     class DashHaOrchTest : public MockOrchTest
     {
     protected:
         std::unique_ptr<MockBfdOrch> m_mockBfdOrch;
+
+        virtual DashHaOrch* CreateDashHaOrch(const vector<string>& dash_ha_tables)
+        {
+            return new DashHaOrch(m_dpu_app_db.get(), dash_ha_tables, m_DashOrch, m_mockBfdOrch.get(), m_dpu_app_state_db.get(), nullptr);
+        }
 
         void PostSetUp() override
         {
@@ -68,7 +87,7 @@ namespace dashhaorch_ut
                 APP_DASH_HA_SET_TABLE_NAME,
                 APP_DASH_HA_SCOPE_TABLE_NAME
             };
-            m_dashHaOrch = new DashHaOrch(m_dpu_app_db.get(), dash_ha_tables, m_DashOrch, m_mockBfdOrch.get(), m_dpu_app_state_db.get(), nullptr);
+            m_dashHaOrch = CreateDashHaOrch(dash_ha_tables);
             gDirectory.set(m_dashHaOrch);
             ut_orch_list.push_back((Orch **)&m_dashHaOrch);
         }
@@ -1065,6 +1084,33 @@ namespace dashhaorch_ut
         EXPECT_EQ(m_mockBfdOrch->createSoftwareBfdSession_invoked_times, 1);
 
         RemoveHaScope();
+        RemoveHaSet();
+    }
+
+    class DashHaOrchTestAdminStateUnsupported : public DashHaOrchTest
+    {
+    protected:
+        DashHaOrch* CreateDashHaOrch(const vector<string>& dash_ha_tables) override
+        {
+            return new DashHaOrchAdminStateUnsupported(m_dpu_app_db.get(), dash_ha_tables, m_DashOrch, m_mockBfdOrch.get(), m_dpu_app_state_db.get(), nullptr);
+        }
+    };
+
+    TEST_F(DashHaOrchTestAdminStateUnsupported, SetHaScopeDisabledWhenAdminStateAttrNotSupported)
+    {
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_set).Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        CreateHaSet();
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_scope).Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        CreateHaScope();
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, set_ha_scope_attribute).Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        SetHaScopeHaRole("active");
+        EXPECT_FALSE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.disabled());
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, remove_ha_scope).Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        RemoveHaScope();
+        EXPECT_CALL(*mock_sai_dash_ha_api, remove_ha_set).Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
         RemoveHaSet();
     }
 }

--- a/tests/mock_tests/dashorch_ut.cpp
+++ b/tests/mock_tests/dashorch_ut.cpp
@@ -24,18 +24,31 @@ namespace dashorch_test
     {
     public:
         MockDashHaOrch(DBConnector *db, const std::vector<std::string> &tableNames, DashOrch *dash_orch, BfdOrch *bfd_orch, DBConnector *app_state_db, ZmqServer *zmqServer)
-            : DashHaOrch(db, tableNames, dash_orch, bfd_orch, app_state_db, zmqServer) {}
+            : DashHaOrch(db, tableNames, dash_orch, bfd_orch, app_state_db, zmqServer), m_ha_role_for_eni(dash::types::HA_ROLE_ACTIVE) {}
+
+        void setHaRoleForEni(dash::types::HaRole role) { m_ha_role_for_eni = role; }
 
         HaScopeEntry getHaScopeForEni(const std::string& eni) override
         {
             HaScopeEntry entry;
 
             entry.ha_scope_id = 0x123456789ABCDEF0ULL;
-            entry.metadata.set_ha_role(dash::types::HA_ROLE_ACTIVE);
+            entry.metadata.set_ha_role(m_ha_role_for_eni);
             entry.metadata.set_disabled(false);
 
             return entry;
         }
+
+    private:
+        dash::types::HaRole m_ha_role_for_eni;
+    };
+
+    class TestableDashOrch : public DashOrch
+    {
+    public:
+        TestableDashOrch(swss::DBConnector* db, std::vector<std::string>& tables, swss::DBConnector* app_state_db, swss::ZmqServer* zmqServer)
+            : DashOrch(db, tables, app_state_db, zmqServer) {}
+        bool isHaFlowOwnerAttrSupported() override { return false; }
     };
 
     DEFINE_SAI_GENERIC_APIS_MOCK(dash_appliance, dash_appliance)
@@ -82,9 +95,10 @@ namespace dashorch_test
         }
     }
     class DashOrchTest : public MockDashOrchTest, public ::testing::WithParamInterface<std::tuple<ValueOrRange, ValueOrRange>> {
-    private:
+    protected:
         std::unique_ptr<MockDashHaOrch> m_mock_dash_ha_orch;
-        
+
+    private:
         void ApplySaiMock()
         {
             INIT_SAI_API_MOCK(dash_appliance);
@@ -96,9 +110,8 @@ namespace dashorch_test
 
         void PostSetUp()
         {
-            // Skip HA orch mocking for now since the dummy value returned by getHaScopeForEni is causing ENI creation to fail.
-            // m_mock_dash_ha_orch = std::make_unique<MockDashHaOrch>(m_dpu_app_db.get(), std::vector<std::string>{APP_DASH_HA_SET_TABLE_NAME, APP_DASH_HA_SCOPE_TABLE_NAME}, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
-            // m_DashOrch->setDashHaOrch(m_mock_dash_ha_orch.get());
+            // Mock is not created here so tests that only need DashOrch (e.g. trusted VNI tests) are not
+            // affected by the dummy getHaScopeForEni(). The two tests that need the mock create it locally.
         }
 
         void PreTearDown() override
@@ -151,6 +164,16 @@ namespace dashorch_test
                     }
                 }
                 return ;
+            }
+            void VerifyHaFlowOwner(std::vector<sai_attribute_t> &actual_attrs, bool expected_value)
+            {
+                for (auto attr : actual_attrs) {
+                    if (attr.id == SAI_ENI_ATTR_IS_HA_FLOW_OWNER) {
+                        EXPECT_EQ(attr.value.booldata, expected_value);
+                        return;
+                    }
+                }
+                FAIL() << "SAI_ENI_ATTR_IS_HA_FLOW_OWNER not found in attributes";
             }
     };
 
@@ -680,5 +703,77 @@ namespace dashorch_test
         appliance.set_outbound_direction_lookup("src_mac");
         SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance);
         VerifyDirectionLookup(actual_attrs, SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION);
+    }
+
+    TEST_F(DashOrchTest, CreateEniWithHaScopeStandbyRole)
+    {
+        m_mock_dash_ha_orch = std::make_unique<MockDashHaOrch>(m_dpu_app_db.get(), std::vector<std::string>{APP_DASH_HA_SET_TABLE_NAME, APP_DASH_HA_SCOPE_TABLE_NAME}, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
+        m_DashOrch->setDashHaOrch(m_mock_dash_ha_orch.get());
+
+        CreateApplianceEntry();
+        CreateVnet();
+        m_mock_dash_ha_orch->setHaRoleForEni(dash::types::HA_ROLE_STANDBY);
+
+        std::vector<sai_attribute_t> actual_attrs;
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1).WillOnce(
+            DoAll(
+                [&actual_attrs](sai_object_id_t *eni_id, sai_object_id_t switch_id, uint32_t attr_count, const sai_attribute_t *attr_list) {
+                    actual_attrs.assign(attr_list, attr_list + attr_count);
+                },
+                Invoke(old_sai_dash_eni_api, &sai_dash_eni_api_t::create_eni)));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        VerifyHaFlowOwner(actual_attrs, false);
+
+        m_DashOrch->setDashHaOrch(nullptr);
+    }
+
+    TEST_F(DashOrchTest, CreateEniWithHaScopeOtherRole)
+    {
+        m_mock_dash_ha_orch = std::make_unique<MockDashHaOrch>(m_dpu_app_db.get(), std::vector<std::string>{APP_DASH_HA_SET_TABLE_NAME, APP_DASH_HA_SCOPE_TABLE_NAME}, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
+        m_DashOrch->setDashHaOrch(m_mock_dash_ha_orch.get());
+
+        CreateApplianceEntry();
+        CreateVnet();
+        m_mock_dash_ha_orch->setHaRoleForEni(dash::types::HA_ROLE_SWITCHING_TO_ACTIVE);
+
+        std::vector<sai_attribute_t> actual_attrs;
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1).WillOnce(
+            DoAll(
+                [&actual_attrs](sai_object_id_t *eni_id, sai_object_id_t switch_id, uint32_t attr_count, const sai_attribute_t *attr_list) {
+                    actual_attrs.assign(attr_list, attr_list + attr_count);
+                },
+                Invoke(old_sai_dash_eni_api, &sai_dash_eni_api_t::create_eni)));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        VerifyHaFlowOwner(actual_attrs, false);
+
+        m_DashOrch->setDashHaOrch(nullptr);
+    }
+
+    class DashOrchTestHaFlowOwnerNotSupported : public DashOrchTest
+    {
+    protected:
+        DashOrch* CreateDashOrch(swss::DBConnector* app_db, const std::vector<std::string>& dash_tables, swss::DBConnector* state_db, swss::ZmqServer* zmq) override
+        {
+            return new TestableDashOrch(app_db, const_cast<std::vector<std::string>&>(dash_tables), state_db, zmq);
+        }
+    };
+
+    TEST_F(DashOrchTestHaFlowOwnerNotSupported, CreateEniWhenHaFlowOwnerAttrNotSupported)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+
+        std::vector<sai_attribute_t> actual_attrs;
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1).WillOnce(
+            DoAll(
+                [&actual_attrs](sai_object_id_t *eni_id, sai_object_id_t switch_id, uint32_t attr_count, const sai_attribute_t *attr_list) {
+                    actual_attrs.assign(attr_list, attr_list + attr_count);
+                },
+                Invoke(old_sai_dash_eni_api, &sai_dash_eni_api_t::create_eni)));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        VerifyNoAttribute(actual_attrs, SAI_ENI_ATTR_IS_HA_FLOW_OWNER);
     }
 }

--- a/tests/mock_tests/hftelprofile_ut.cpp
+++ b/tests/mock_tests/hftelprofile_ut.cpp
@@ -1,0 +1,239 @@
+// Pre-include standard library and third-party headers that conflict with
+// the #define private public hack (they use 'private' internally).
+#include <sstream>
+#include <string>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <set>
+#include <memory>
+
+#define private public
+#define protected public
+#include "high_frequency_telemetry/hftelprofile.h"
+#undef private
+#undef protected
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include <gtest/gtest.h>
+
+extern sai_tam_api_t *sai_tam_api;
+
+namespace hftelprofile_ut
+{
+    using namespace std;
+
+    /*
+     * Mock state for sai_tam_api->get_tam_tel_type_attribute.
+     * Controls what the mock returns on each successive call.
+     */
+    struct MockGetTelTypeAttrState
+    {
+        sai_status_t first_call_status = SAI_STATUS_BUFFER_OVERFLOW;
+        uint32_t     first_call_count  = 0;
+        sai_status_t second_call_status = SAI_STATUS_SUCCESS;
+        vector<uint8_t> template_data;
+        int call_count = 0;
+    };
+
+    static MockGetTelTypeAttrState g_mock;
+
+    static sai_status_t mock_get_tam_tel_type_attribute(
+        sai_object_id_t /*id*/, uint32_t attr_count, sai_attribute_t *attr_list)
+    {
+        ++g_mock.call_count;
+
+        if (attr_count != 1 || !attr_list ||
+            attr_list[0].id != SAI_TAM_TEL_TYPE_ATTR_IPFIX_TEMPLATES)
+        {
+            return SAI_STATUS_INVALID_PARAMETER;
+        }
+
+        if (g_mock.call_count == 1)
+        {
+            /* First call — size query (count=0, list=nullptr). */
+            attr_list[0].value.u8list.count = g_mock.first_call_count;
+            return g_mock.first_call_status;
+        }
+
+        /* Second call — data fetch. */
+        if (g_mock.second_call_status == SAI_STATUS_SUCCESS &&
+            !g_mock.template_data.empty())
+        {
+            auto n = min(static_cast<uint32_t>(g_mock.template_data.size()),
+                         attr_list[0].value.u8list.count);
+            memcpy(attr_list[0].value.u8list.list,
+                   g_mock.template_data.data(), n);
+            attr_list[0].value.u8list.count = n;
+        }
+        return g_mock.second_call_status;
+    }
+
+    /*
+     * Fixture: swaps sai_tam_api->get_tam_tel_type_attribute with our mock
+     * for each test, restoring the original on tear-down.
+     */
+    struct UpdateTemplatesTest : public ::testing::Test
+    {
+        sai_tam_api_t  ut_api;
+        sai_tam_api_t *orig_api;
+
+        /* Minimal state to call updateTemplates(). */
+        sai_object_id_t fake_tel_type_oid = 0x100;
+        HFTelProfile::sai_guard_t guard;
+        CounterNameCache empty_cache;
+
+        void SetUp() override
+        {
+            if (sai_tam_api == nullptr)
+            {
+                static sai_tam_api_t default_tam_api{};
+                sai_tam_api = &default_tam_api;
+            }
+            ut_api   = *sai_tam_api;
+            orig_api =  sai_tam_api;
+            ut_api.get_tam_tel_type_attribute = mock_get_tam_tel_type_attribute;
+            sai_tam_api = &ut_api;
+
+            g_mock = MockGetTelTypeAttrState{};
+            guard  = make_shared<sai_object_id_t>(fake_tel_type_oid);
+        }
+
+        void TearDown() override { sai_tam_api = orig_api; }
+
+        /*
+         * Build a *partially-constructed* HFTelProfile that is just enough
+         * for updateTemplates() to run.  We skip the real constructor
+         * (which calls initTelemetry → SAI) by using raw allocation +
+         * placement construction of only the members we need.
+         *
+         * This is deliberately minimal; we only touch the three maps that
+         * updateTemplates() and getObjectType() read/write.
+         */
+        struct Stub
+        {
+            alignas(HFTelProfile) unsigned char buf[sizeof(HFTelProfile)];
+            HFTelProfile *p = nullptr;
+
+            void init(HFTelProfile::sai_guard_t &guard)
+            {
+                /*
+                 * Zero the storage so any incidental reads of uninitialised
+                 * scalar members are safe (e.g. m_poll_interval).
+                 */
+                memset(buf, 0, sizeof(buf));
+                p = reinterpret_cast<HFTelProfile *>(static_cast<void *>(buf));
+
+                /* Placement-new the containers and strings that may be
+                 * accessed (directly or via logging) by updateTemplates().
+                 * Today that means:
+                 *   - m_profile_name
+                 *   - m_sai_tam_tel_type_objs
+                 *   - m_sai_tam_tel_type_templates
+                 * If updateTemplates() starts touching additional members,
+                 * extend this partial construction accordingly. */
+                new (const_cast<string*>(&p->m_profile_name)) string();
+                new (&p->m_sai_tam_tel_type_objs)
+                    decay_t<decltype(p->m_sai_tam_tel_type_objs)>();
+                new (&p->m_sai_tam_tel_type_templates)
+                    decay_t<decltype(p->m_sai_tam_tel_type_templates)>();
+
+                p->m_sai_tam_tel_type_objs[SAI_OBJECT_TYPE_PORT] = guard;
+            }
+
+            ~Stub()
+            {
+                if (!p) return;
+                p->m_profile_name.~basic_string();
+                p->m_sai_tam_tel_type_objs.~unordered_map();
+                p->m_sai_tam_tel_type_templates.~unordered_map();
+                p = nullptr;
+            }
+        };
+    };
+
+    /* ---- SAI returns BUFFER_OVERFLOW then SUCCESS (happy path) ---- */
+    TEST_F(UpdateTemplatesTest, BufferOverflow_ThenSuccess)
+    {
+        Stub s;
+        s.init(guard);
+
+        g_mock.first_call_status  = SAI_STATUS_BUFFER_OVERFLOW;
+        g_mock.first_call_count   = 4;
+        g_mock.second_call_status = SAI_STATUS_SUCCESS;
+        g_mock.template_data      = {0xAA, 0xBB, 0xCC, 0xDD};
+
+        ASSERT_NO_THROW(s.p->updateTemplates(fake_tel_type_oid));
+
+        auto &tpl = s.p->m_sai_tam_tel_type_templates[SAI_OBJECT_TYPE_PORT];
+        ASSERT_EQ(tpl.size(), 4u);
+        EXPECT_EQ(tpl[0], 0xAA);
+        EXPECT_EQ(tpl[3], 0xDD);
+    }
+
+    /* ---- SAI returns SUCCESS on first call (count stays 0) ---- */
+    TEST_F(UpdateTemplatesTest, Success_EmptyTemplate)
+    {
+        Stub s;
+        s.init(guard);
+
+        g_mock.first_call_status = SAI_STATUS_SUCCESS;
+        g_mock.first_call_count  = 0;
+
+        ASSERT_NO_THROW(s.p->updateTemplates(fake_tel_type_oid));
+
+        auto &tpl = s.p->m_sai_tam_tel_type_templates[SAI_OBJECT_TYPE_PORT];
+        EXPECT_TRUE(tpl.empty());
+    }
+
+    /* ---- BUFFER_OVERFLOW with count=0 stores an empty template ---- */
+    TEST_F(UpdateTemplatesTest, BufferOverflow_EmptyTemplate)
+    {
+        Stub s;
+        s.init(guard);
+
+        g_mock.first_call_status = SAI_STATUS_BUFFER_OVERFLOW;
+        g_mock.first_call_count  = 0;
+
+        ASSERT_NO_THROW(s.p->updateTemplates(fake_tel_type_oid));
+
+        auto &tpl = s.p->m_sai_tam_tel_type_templates[SAI_OBJECT_TYPE_PORT];
+        EXPECT_TRUE(tpl.empty());
+        EXPECT_EQ(g_mock.call_count, 1);
+    }
+
+    /* ---- First query fails with unexpected status ---- */
+    TEST_F(UpdateTemplatesTest, FirstCall_UnexpectedFailure)
+    {
+        Stub s;
+        s.init(guard);
+
+        g_mock.first_call_status = SAI_STATUS_FAILURE;
+
+        EXPECT_THROW(s.p->updateTemplates(fake_tel_type_oid), runtime_error);
+    }
+
+    /* ---- Second call (data fetch) fails ---- */
+    TEST_F(UpdateTemplatesTest, SecondCall_Failure)
+    {
+        Stub s;
+        s.init(guard);
+
+        g_mock.first_call_status  = SAI_STATUS_BUFFER_OVERFLOW;
+        g_mock.first_call_count   = 4;
+        g_mock.second_call_status = SAI_STATUS_FAILURE;
+
+        EXPECT_THROW(s.p->updateTemplates(fake_tel_type_oid), runtime_error);
+    }
+
+    /* ---- Unknown tel-type OID → object type not found ---- */
+    TEST_F(UpdateTemplatesTest, UnknownOID_Throws)
+    {
+        Stub s;
+        s.init(guard);
+
+        sai_object_id_t bad_oid = 0xDEAD;
+        EXPECT_THROW(s.p->updateTemplates(bad_oid), runtime_error);
+    }
+}

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -26,6 +26,11 @@ void MockOrchTest::initTestLogger(const std::string &appName, int minPrio)
     }
 }
 
+DashOrch* MockOrchTest::CreateDashOrch(swss::DBConnector* app_db, const std::vector<std::string>& dash_tables, swss::DBConnector* state_db, swss::ZmqServer* zmq)
+{
+    return new DashOrch(app_db, const_cast<std::vector<std::string>&>(dash_tables), state_db, zmq);
+}
+
 void MockOrchTest::PrepareSai()
 {
     sai_attribute_t attr;
@@ -265,7 +270,7 @@ void MockOrchTest::SetUp()
         APP_DASH_QOS_TABLE_NAME
     };
 
-    m_DashOrch = new DashOrch(m_app_db.get(), dash_tables, m_dpu_app_state_db.get(), nullptr);
+    m_DashOrch = CreateDashOrch(m_app_db.get(), dash_tables, m_dpu_app_state_db.get(), nullptr);
     gDirectory.set(m_DashOrch);
     ut_orch_list.push_back((Orch **)&m_DashOrch);
 

--- a/tests/mock_tests/mock_orch_test.h
+++ b/tests/mock_tests/mock_orch_test.h
@@ -70,5 +70,6 @@ namespace mock_orch_test
         virtual void PreTearDown();
         virtual void ApplySaiMock();
         void initTestLogger(const std::string &appName = "mock_tests", int minPrio = swss::Logger::SWSS_INFO);
+        virtual DashOrch* CreateDashOrch(swss::DBConnector* app_db, const std::vector<std::string>& dash_tables, swss::DBConnector* state_db, swss::ZmqServer* zmq);
     };
 }

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -41,6 +41,20 @@ int __wrap_nl_send_auto(struct nl_sock *sk, struct nl_msg *msg)
     return 0;
 }
 
+/* Control whether nlmsg_alloc returns NULL to simulate setNeighbor failure */
+static bool mock_nlmsg_alloc_fail = false;
+
+struct nl_msg *__wrap_nlmsg_alloc(void)
+{
+    if (mock_nlmsg_alloc_fail)
+    {
+        return nullptr;
+    }
+    /* Call real implementation */
+    struct nl_msg *__real_nlmsg_alloc(void);
+    return __real_nlmsg_alloc();
+}
+
 unsigned int __wrap_if_nametoindex(const char *ifname)
 {
     /* Return a dummy interface index */
@@ -73,6 +87,7 @@ namespace nbrmgr_ut
 
             mockCallArgs.clear();
             neighResolvedKeys.clear();
+            mock_nlmsg_alloc_fail = false;
             callback = noop_cb;
         }
     };
@@ -142,5 +157,48 @@ namespace nbrmgr_ut
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
 
         /* Verify construction completes - IPv6 entries are reconciled */
+    }
+
+    /*
+     * Test that entries with invalid key format (no ':' separator)
+     * are skipped during reconciliation.
+     */
+    TEST_F(NbrMgrTest, ReconcileInvalidKeyFormat)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+
+        swss::Table neighResolveTable(m_app_db.get(), APP_NEIGH_RESOLVE_TABLE_NAME);
+        std::vector<swss::FieldValueTuple> fvs;
+        /* Valid entry */
+        neighResolveTable.set("Ethernet0:10.0.0.1", fvs);
+        /* Invalid entry - no ':' separator */
+        neighResolveTable.set("InvalidKeyNoSeparator", fvs);
+
+        std::vector<std::string> keys;
+        neighResolveTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 2u);
+
+        /* Should not crash; invalid key is skipped, valid key is processed */
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+    }
+
+    /*
+     * Test that setNeighbor failure during reconciliation is handled
+     * gracefully (logs warning, continues with remaining entries).
+     */
+    TEST_F(NbrMgrTest, ReconcileSetNeighborFailure)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+
+        swss::Table neighResolveTable(m_app_db.get(), APP_NEIGH_RESOLVE_TABLE_NAME);
+        std::vector<swss::FieldValueTuple> fvs;
+        neighResolveTable.set("Ethernet0:10.0.0.1", fvs);
+        neighResolveTable.set("Ethernet4:10.0.0.3", fvs);
+
+        /* Force nlmsg_alloc to fail, causing setNeighbor to return false */
+        mock_nlmsg_alloc_fail = true;
+
+        /* Should not crash; failures are logged as warnings */
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
     }
 }

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -44,14 +44,14 @@ int __wrap_nl_send_auto(struct nl_sock *sk, struct nl_msg *msg)
 /* Control whether nlmsg_alloc returns NULL to simulate setNeighbor failure */
 static bool mock_nlmsg_alloc_fail = false;
 
+struct nl_msg *__real_nlmsg_alloc(void);
+
 struct nl_msg *__wrap_nlmsg_alloc(void)
 {
     if (mock_nlmsg_alloc_fail)
     {
         return nullptr;
     }
-    /* Call real implementation */
-    struct nl_msg *__real_nlmsg_alloc(void);
     return __real_nlmsg_alloc();
 }
 

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -1,0 +1,146 @@
+#include "gtest/gtest.h"
+#include <iostream>
+#include <netlink/netlink.h>
+#include <netlink/msg.h>
+#include <net/if.h>
+#include "../mock_table.h"
+#include "warm_restart.h"
+#define private public
+#include "nbrmgr.h"
+#undef private
+
+extern int (*callback)(const std::string &cmd, std::string &stdout);
+extern std::vector<std::string> mockCallArgs;
+
+/* Track netlink neighbor resolve calls */
+static std::vector<std::string> neighResolvedKeys;
+
+/*
+ * Wrap netlink and interface functions to avoid real kernel interaction.
+ * setNeighbor() calls nl_socket_alloc, nl_connect, if_nametoindex, and
+ * nl_send_auto. We intercept nl_send_auto to record the call and
+ * if_nametoindex to return a dummy index.
+ */
+extern "C" {
+
+struct nl_sock *__wrap_nl_socket_alloc(void)
+{
+    /* Return a non-null fake pointer; nl_sock is opaque so cast from raw memory */
+    static char fake_sock_mem[256];
+    return reinterpret_cast<struct nl_sock *>(fake_sock_mem);
+}
+
+int __wrap_nl_connect(struct nl_sock *sk, int protocol)
+{
+    return 0;
+}
+
+int __wrap_nl_send_auto(struct nl_sock *sk, struct nl_msg *msg)
+{
+    /* Record that a neighbor resolve was attempted */
+    return 0;
+}
+
+unsigned int __wrap_if_nametoindex(const char *ifname)
+{
+    /* Return a dummy interface index */
+    return 1;
+}
+
+}
+
+int noop_cb(const std::string &cmd, std::string &out){
+    mockCallArgs.push_back(cmd);
+    return 0;
+}
+
+namespace nbrmgr_ut
+{
+    struct NbrMgrTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_config_db;
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::DBConnector> m_state_db;
+
+        virtual void SetUp() override
+        {
+            testing_db::reset();
+            m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+
+            swss::WarmStart::initialize("nbrmgrd", "swss");
+
+            mockCallArgs.clear();
+            neighResolvedKeys.clear();
+            callback = noop_cb;
+        }
+    };
+
+    /*
+     * Test that when NEIGH_RESOLVE_TABLE is empty at startup,
+     * NbrMgr constructs successfully without errors.
+     */
+    TEST_F(NbrMgrTest, ReconcileEmptyTable)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+
+        /* No entries in NEIGH_RESOLVE_TABLE - should construct without issue */
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+
+        /* Verify the table is indeed empty */
+        swss::Table neighResolveTable(m_app_db.get(), APP_NEIGH_RESOLVE_TABLE_NAME);
+        std::vector<std::string> keys;
+        neighResolveTable.getKeys(keys);
+        ASSERT_TRUE(keys.empty());
+    }
+
+    /*
+     * Test that pre-existing entries in NEIGH_RESOLVE_TABLE are
+     * picked up and processed during NbrMgr construction.
+     */
+    TEST_F(NbrMgrTest, ReconcilePendingEntries)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+
+        /* Pre-populate NEIGH_RESOLVE_TABLE with entries (simulating entries
+         * left over from before a restart) */
+        swss::Table neighResolveTable(m_app_db.get(), APP_NEIGH_RESOLVE_TABLE_NAME);
+        std::vector<swss::FieldValueTuple> fvs;
+        fvs.emplace_back("family", "IPv4");
+        neighResolveTable.set("Ethernet0:10.0.0.1", fvs);
+        neighResolveTable.set("Ethernet4:10.0.0.3", fvs);
+
+        /* Verify entries exist before construction */
+        std::vector<std::string> keys;
+        neighResolveTable.getKeys(keys);
+        ASSERT_EQ(keys.size(), 2u);
+
+        /* Construct NbrMgr - reconciliation should process these entries */
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+
+        /* NbrMgr constructor calls setNeighbor for each entry via
+         * reconcileNeighResolveTable. Since setNeighbor uses netlink
+         * (wrapped here), we verify construction succeeds without error.
+         * The entries are resolved via netlink, not removed from the table
+         * (orchagent removes them after neighbor is learned). */
+    }
+
+    /*
+     * Test reconciliation with IPv6 entries.
+     */
+    TEST_F(NbrMgrTest, ReconcileIPv6Entries)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+
+        swss::Table neighResolveTable(m_app_db.get(), APP_NEIGH_RESOLVE_TABLE_NAME);
+        std::vector<swss::FieldValueTuple> fvs;
+        fvs.emplace_back("family", "IPv6");
+        neighResolveTable.set("Ethernet0:2000::2", fvs);
+        neighResolveTable.set("Ethernet4:2001::2", fvs);
+
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+
+        /* Verify construction completes - IPv6 entries are reconciled */
+    }
+}

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -1,0 +1,506 @@
+/**
+ * @file portphyserdesattr_ut.cpp
+ * @brief Unit tests for PORT_SERDES_ATTR flex counter orchestration
+ *
+ * Tests the end-to-end integration of PHY SERDES attribute collection from
+ * FlexCounterOrch through PortsOrch to the FlexCounter infrastructure.
+ */
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_orch_test.h"
+#include "mock_table.h"
+
+#include <memory>
+#include <string>
+
+extern SwitchOrch *gSwitchOrch;
+extern PortsOrch *gPortsOrch;
+extern BufferOrch *gBufferOrch;
+
+namespace portphyserdesattr_test
+{
+    using namespace std;
+
+    // Mock flex counter infrastructure
+    shared_ptr<swss::DBConnector> mockFlexCounterDb;
+    shared_ptr<swss::Table> mockFlexCounterTable;
+    sai_switch_api_t ut_sai_switch_api;
+    sai_switch_api_t *pold_sai_switch_api;
+    sai_port_api_t ut_sai_port_api;
+    sai_port_api_t *pold_sai_port_api;
+
+    // Test mode flag for partial attribute support testing
+    bool g_test_partial_support_mode = false;
+
+    // RAII guard to ensure g_test_partial_support_mode is always restored
+    class PartialSupportModeGuard
+    {
+    public:
+        PartialSupportModeGuard()
+        {
+            g_test_partial_support_mode = true;
+        }
+        ~PartialSupportModeGuard()
+        {
+            g_test_partial_support_mode = false;
+        }
+    };
+
+    // Mock SAI get_port_serdes_attribute to simulate SERDES capability checks
+    sai_status_t _ut_stub_sai_get_port_serdes_attribute(
+        _In_ sai_object_id_t port_serdes_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+    {
+        // Simulate successful capability check by returning SAI_STATUS_BUFFER_OVERFLOW
+        // This indicates the attribute is supported but we need to know the buffer size
+        if (attr_count > 0)
+        {
+            if (attr_list[0].id == SAI_PORT_SERDES_ATTR_RX_VGA)
+            {
+                // Simulate that RX_VGA is supported with 4 lanes
+                attr_list[0].value.u32list.count = 4;
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+            else if (attr_list[0].id == SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST)
+            {
+                // In partial support mode, simulate TX_FIR_TAPS_LIST as NOT supported
+                if (g_test_partial_support_mode)
+                {
+                    return SAI_STATUS_NOT_SUPPORTED;
+                }
+
+                // Simulate that TX_FIR_TAPS_LIST is supported with 4 lanes
+                attr_list[0].value.portserdestaps.count = 4;
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+        }
+
+        // Call original implementation for other attributes
+        return pold_sai_port_api->get_port_serdes_attribute(port_serdes_id, attr_count, attr_list);
+    }
+
+    // Mock SAI set_switch_attribute to intercept flex counter operations
+    sai_status_t mockFlexCounterOperation(sai_object_id_t objectId, const sai_attribute_t *attr)
+    {
+        if (objectId != gSwitchId)
+        {
+            return SAI_STATUS_FAILURE;
+        }
+
+        auto *param = reinterpret_cast<sai_redis_flex_counter_parameter_t*>(attr->value.ptr);
+        std::vector<swss::FieldValueTuple> entries;
+        std::string key((const char*)param->counter_key.list);
+
+        // Extract group name and OID(s) from key (format: "GROUP_NAME:oid1,oid2,...")
+        auto delimiter = key.find_first_of(":");
+        if (delimiter == std::string::npos)
+        {
+            return SAI_STATUS_FAILURE;
+        }
+
+        std::string groupName = key.substr(0, delimiter);
+        std::string strOids = key.substr(delimiter + 1);
+
+        // Split OIDs by comma (mimics syncd behavior in Syncd.cpp:3144)
+        std::vector<std::string> oidVector;
+        size_t start = 0;
+        size_t end = strOids.find(',');
+        while (end != std::string::npos)
+        {
+            oidVector.push_back(strOids.substr(start, end - start));
+            start = end + 1;
+            end = strOids.find(',', start);
+        }
+        oidVector.push_back(strOids.substr(start));
+
+        if (param->counter_ids.list != nullptr)
+        {
+            entries.push_back({(const char*)param->counter_field_name.list, (const char*)param->counter_ids.list});
+
+            if (param->stats_mode.list != nullptr)
+            {
+                entries.push_back({STATS_MODE_FIELD, (const char*)param->stats_mode.list});
+            }
+
+            // Create individual entries for each OID (mimics syncd behavior in Syncd.cpp:3174-3177)
+            for (const auto& oid : oidVector)
+            {
+                std::string singleKey = groupName + ":" + oid;
+                mockFlexCounterTable->set(singleKey, entries);
+            }
+        }
+        else
+        {
+            // Delete individual entries for each OID
+            for (const auto& oid : oidVector)
+            {
+                std::string singleKey = groupName + ":" + oid;
+                mockFlexCounterTable->del(singleKey);
+            }
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_set_switch_attribute(sai_object_id_t switch_id, const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER)
+        {
+            return mockFlexCounterOperation(switch_id, attr);
+        }
+        return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
+    }
+
+    void _hook_sai_switch_api()
+    {
+        mockFlexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        mockFlexCounterTable = make_shared<swss::Table>(mockFlexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        // Hook switch API for flex counter operations
+        ut_sai_switch_api = *sai_switch_api;
+        pold_sai_switch_api = sai_switch_api;
+        ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+        sai_switch_api = &ut_sai_switch_api;
+
+        // Hook port API for port serdes attribute capability checks
+        ut_sai_port_api = *sai_port_api;
+        pold_sai_port_api = sai_port_api;
+        ut_sai_port_api.get_port_serdes_attribute = _ut_stub_sai_get_port_serdes_attribute;
+        sai_port_api = &ut_sai_port_api;
+    }
+
+    void _unhook_sai_switch_api()
+    {
+        sai_switch_api = pold_sai_switch_api;
+        sai_port_api = pold_sai_port_api;
+    }
+
+    struct PortSerdesAttrTest : public ::testing::Test
+    {
+        PortSerdesAttrTest() {}
+
+        void SetUp() override
+        {
+            ::testing_db::reset();
+
+            // Initialize database connections
+            m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+            m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+            m_counters_db = make_shared<swss::DBConnector>("COUNTERS_DB", 0);
+
+            // Create SwitchOrch dependencies
+            // Required for SAI switch initialization in the mock environment
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+            // Create PortsOrch with all required table dependencies
+            const int portsorch_base_pri = 40;
+            vector<table_name_with_pri_t> port_tables = {
+                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },                // Physical port config (highest priority)
+                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 }, // Ingress port forwarding
+                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },                // VLAN configuration
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },             // VLAN membership (lowest priority)
+                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },                 // Link aggregation groups
+                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }               // LAG membership
+            };
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), port_tables, m_chassis_app_db.get());
+
+            vector<string> flex_counter_tables = {CFG_FLEX_COUNTER_TABLE_NAME};
+            m_flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+
+            // Register FlexCounterOrch in gDirectory for PortsOrch to access via gDirectory.get<FlexCounterOrch*>()
+            gDirectory.set(m_flexCounterOrch);
+
+            // Create BufferOrch - required by PortsOrch for port initialization
+            vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
+                                             APP_BUFFER_PROFILE_TABLE_NAME,
+                                             APP_BUFFER_QUEUE_TABLE_NAME,
+                                             APP_BUFFER_PG_TABLE_NAME,
+                                             APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                                             APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME };
+            gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+
+            // Initialize ports using SAI default ports
+            Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+            auto ports = ut_helper::getInitialSaiPorts();
+            for (const auto &it : ports)
+            {
+                portTable.set(it.first, it.second);
+            }
+
+            // Set PortConfigDone
+            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            // Signal that port initialization is complete
+            portTable.set("PortInitDone", { { "lanes", "0" } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+        }
+
+        void TearDown() override
+        {
+            ::testing_db::reset();
+
+            gDirectory.m_values.clear();
+
+            delete m_flexCounterOrch;
+            m_flexCounterOrch = nullptr;
+
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+
+            delete gPortsOrch;
+            gPortsOrch = nullptr;
+
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
+        }
+
+        static void SetUpTestCase()
+        {
+            // Initialize the SAI virtual switch environment for unit testing
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },  // Simulate Broadcom switch
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }         // Test MAC address
+            };
+
+            // Initialize the SAI API with virtual switch support
+            auto status = ut_helper::initSaiApi(profile);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr;
+
+            // Create the virtual switch instance
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Hook SAI switch API to intercept flex counter operations
+            _hook_sai_switch_api();
+        }
+
+        static void TearDownTestCase()
+        {
+            _unhook_sai_switch_api();
+
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gSwitchId = 0;
+
+            ut_helper::uninitSaiApi();
+        }
+
+
+        shared_ptr<swss::DBConnector> m_app_db;
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_chassis_app_db;
+        shared_ptr<swss::DBConnector> m_counters_db;
+        shared_ptr<swss::DBConnector> m_flex_counter_db;
+
+        FlexCounterOrch* m_flexCounterOrch = nullptr;
+    };
+
+    /**
+     * PORT_SERDES_ATTR flex counter enable/disable via doTask
+     */
+    TEST_F(PortSerdesAttrTest, EnablePortSerdesAttrFlexCounterDoTask)
+    {
+        ASSERT_NE(m_flexCounterOrch, nullptr);
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        bool initialState = m_flexCounterOrch->getPortPhySerdesAttrCountersState();
+        EXPECT_FALSE(initialState);
+
+        auto consumer = dynamic_cast<Consumer *>(m_flexCounterOrch->getExecutor(CFG_FLEX_COUNTER_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
+
+        Table flexCounterTable(m_config_db.get(), CFG_FLEX_COUNTER_TABLE_NAME);
+        vector<FieldValueTuple> fvs;
+        fvs.push_back(FieldValueTuple("FLEX_COUNTER_STATUS", "enable"));
+        fvs.push_back(FieldValueTuple("POLL_INTERVAL", "1000"));
+        flexCounterTable.set("PORT_PHY_ATTR", fvs);
+        std::cout << " CONFIG_DB configured: FLEX_COUNTER_STATUS=enable, POLL_INTERVAL=1000" << std::endl;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"PORT_PHY_ATTR", "SET", {
+            {"FLEX_COUNTER_STATUS", "enable"},
+            {"POLL_INTERVAL", "1000"}
+        }});
+
+        consumer->addToSync(entries);
+        static_cast<Orch *>(m_flexCounterOrch)->doTask(*consumer);
+
+        bool state = m_flexCounterOrch->getPortPhySerdesAttrCountersState();
+        EXPECT_TRUE(state);
+        std::cout << " PORT_PHY_SERDES_ATTR enablement verified: state = " << (state ? "ENABLED" : "DISABLED") << std::endl;
+
+        entries.clear();
+        entries.push_back({"PORT_PHY_ATTR", "SET", {{"FLEX_COUNTER_STATUS", "disable"}}});
+
+        consumer->addToSync(entries);
+        static_cast<Orch *>(m_flexCounterOrch)->doTask(*consumer);
+
+        bool disabledState = m_flexCounterOrch->getPortPhySerdesAttrCountersState();
+        EXPECT_FALSE(disabledState);
+        std::cout << " PORT_PHY_SERDES_ATTR disablement verified: state = " << (disabledState ? "ENABLED" : "DISABLED") << std::endl;
+    }
+
+    TEST_F(PortSerdesAttrTest, QueryPortSerdesAttrCapabilitiesWithMockedSAI)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+	// queryPortPhySerdesAttrCapabilities() is called  in PortsOrch Constructor
+        ASSERT_FALSE(gPortsOrch->m_supported_phy_serdes_attrs.empty());
+
+        for (const auto& attr : gPortsOrch->m_supported_phy_serdes_attrs)
+        {
+            EXPECT_TRUE(attr == SAI_PORT_SERDES_ATTR_RX_VGA ||
+                       attr == SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST);
+        }
+    }
+
+    TEST_F(PortSerdesAttrTest, VerifyFlexCountersDBEntriesAfterGenerate)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        auto flexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        auto flexCounterTable = make_shared<swss::Table>(flexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        gPortsOrch->generatePortPhySerdesAttrCounterMap();
+
+        // Flush cached flex counters to trigger the mock SAI API which writes to FLEX_COUNTER_DB
+        gPortsOrch->flushCounters();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        sai_object_id_t port_serdes_id = gPortsOrch->getPortSerdesIdFromPortId(port.m_port_id);
+
+        if (port_serdes_id == SAI_NULL_OBJECT_ID)
+        {
+            SUCCEED() << "Port does not have a valid SERDES ID, skipping verification";
+            return;
+        }
+
+        auto supported_attrs = gPortsOrch->getPortPhySerdesSupportedAttrs(port_serdes_id, port.m_alias.c_str());
+        if (supported_attrs.empty())
+        {
+            SUCCEED();
+            return;
+        }
+
+        std::string key = "PORT_PHY_SERDES_ATTR:" + sai_serialize_object_id(port_serdes_id);
+
+        std::vector<FieldValueTuple> fieldValues;
+        bool entryExists = flexCounterTable->get(key, fieldValues);
+
+	EXPECT_TRUE(entryExists);
+
+        if (entryExists)
+        {
+            bool foundCounterList = false;
+            for (const auto &fv : fieldValues)
+            {
+                if (fvField(fv) == "PORT_PHY_SERDES_ATTR_ID_LIST")
+                {
+                    foundCounterList = true;
+                    std::string counterList = fvValue(fv);
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_RX_VGA") != std::string::npos);
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST") != std::string::npos);
+                }
+            }
+            EXPECT_TRUE(foundCounterList);
+        }
+
+        gPortsOrch->clearPortPhySerdesAttrCounterMap();
+        fieldValues.clear();
+        bool entryExistsAfterClear = flexCounterTable->get(key, fieldValues);
+        EXPECT_FALSE(entryExistsAfterClear);
+    }
+
+    TEST_F(PortSerdesAttrTest, PartialAttributeSupport_OnlyRxVgaSupported)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        // Enable partial support mode: only RX_VGA supported, TX_FIR_TAPS_LIST not supported
+        PartialSupportModeGuard partialSupportGuard;
+
+        auto flexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        auto flexCounterTable = make_shared<swss::Table>(flexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        // Generate counter map with partial support
+        gPortsOrch->generatePortPhySerdesAttrCounterMap();
+
+        // Flush cached flex counters to trigger the mock SAI API which writes to FLEX_COUNTER_DB
+        gPortsOrch->flushCounters();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        sai_object_id_t port_serdes_id = gPortsOrch->getPortSerdesIdFromPortId(port.m_port_id);
+
+        if (port_serdes_id == SAI_NULL_OBJECT_ID)
+        {
+            SUCCEED() << "Port does not have a valid SERDES ID, skipping verification";
+            return;
+        }
+
+        // Verify that only RX_VGA is in the supported list
+        auto supported_attrs = gPortsOrch->getPortPhySerdesSupportedAttrs(port_serdes_id, port.m_alias.c_str());
+        EXPECT_FALSE(supported_attrs.empty());
+        EXPECT_EQ(supported_attrs.size(), 1);
+        EXPECT_EQ(supported_attrs[0], SAI_PORT_SERDES_ATTR_RX_VGA);
+
+        std::string key = "PORT_PHY_SERDES_ATTR:" + sai_serialize_object_id(port_serdes_id);
+
+        std::vector<FieldValueTuple> fieldValues;
+        bool entryExists = flexCounterTable->get(key, fieldValues);
+
+        EXPECT_TRUE(entryExists);
+
+        if (entryExists)
+        {
+            bool foundCounterList = false;
+            for (const auto &fv : fieldValues)
+            {
+                if (fvField(fv) == "PORT_PHY_SERDES_ATTR_ID_LIST")
+                {
+                    foundCounterList = true;
+                    std::string counterList = fvValue(fv);
+
+                    // Should contain RX_VGA
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_RX_VGA") != std::string::npos);
+
+                    // Should NOT contain TX_FIR_TAPS_LIST
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST") == std::string::npos);
+
+                    std::cout << "Partial support verified: counter list = " << counterList << std::endl;
+                }
+            }
+            EXPECT_TRUE(foundCounterList);
+        }
+
+        // Cleanup
+        gPortsOrch->clearPortPhySerdesAttrCounterMap();
+    }
+} // namespace portphyserdesattr_test
+

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -344,6 +344,21 @@ namespace portsorch_test
         _In_ sai_object_id_t port_serdes_id)
     {
         _sai_remove_port_serdes_calls.push_back(port_serdes_id);
+
+        // Erase any port-to-serdes mappings that reference this serdes ID,
+        // so subsequent SAI_PORT_ATTR_PORT_SERDES_ID queries reflect removal.
+        for (auto it = _port_to_serdes_map.begin(); it != _port_to_serdes_map.end(); )
+        {
+            if (it->second == port_serdes_id)
+            {
+                it = _port_to_serdes_map.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
         return SAI_STATUS_SUCCESS;
     }
 

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -1,0 +1,185 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <dlfcn.h>
+#include <stdexcept>
+#include <team.h>
+#include <teamdctl.h>
+#include "teamsync.h"
+
+static unsigned int (*callback_sleep)(unsigned int seconds) = NULL;
+static int (*callback_team_init)(struct team_handle *th, uint32_t ifindex) = NULL;
+static int (*callback_team_change_handler)(struct team_handle *th, struct team_change_handler *handler, void *priv) = NULL;
+static int (*callback_teamdctl_connect)(struct teamdctl *tdc, const char *team_name, const char *addr, const char *cli_type) = NULL;
+static int (*callback_teamdctl_config_get_raw_direct)(struct teamdctl *tdc, char **response) = NULL;
+static void (*callback_teamdctl_disconnect)(struct teamdctl *tdc) = NULL;
+
+static unsigned int cb_sleep(unsigned int seconds)
+{
+    return 0;
+}
+
+unsigned int sleep(unsigned int seconds)
+{
+    if (callback_sleep)
+    {
+        return callback_sleep(seconds);
+    }
+    unsigned int (*realfunc)(unsigned int) =
+        (unsigned int    (*)(unsigned int))(dlsym (RTLD_NEXT, "sleep"));
+    return realfunc(seconds);
+}
+
+
+static int cb_team_init(struct team_handle *th, uint32_t ifindex)
+{
+    return 0;
+}
+
+int team_init(struct team_handle *th, uint32_t ifindex)
+{
+    if (callback_team_init)
+    {
+        return callback_team_init(th, ifindex);
+    }
+    int (*realfunc)(struct team_handle *, uint32_t) =
+        (int    (*)(struct team_handle *, uint32_t))(dlsym (RTLD_NEXT, "team_init"));
+    return realfunc(th, ifindex);
+}
+
+static int cb_team_change_handler(struct team_handle *th, struct team_change_handler *handler, void *priv)
+{
+    return 0;
+}
+
+int team_change_handler(struct team_handle *th, struct team_change_handler *handler, void *priv)
+{
+    if (callback_team_change_handler)
+    {
+        return callback_team_change_handler(th, handler, priv);
+    }
+    int (*realfunc)(struct team_handle *, struct team_change_handler*, void*) =
+        (int    (*)(struct team_handle *, struct team_change_handler*, void*))(dlsym (RTLD_NEXT, "team_change_handler"));
+    return realfunc(th, handler, priv);
+}
+
+static int cb_teamdctl_connect(struct teamdctl *tdc, const char *team_name, const char *addr, const char *cli_type)
+{
+    return 0;
+}
+
+int teamdctl_connect(struct teamdctl *tdc, const char *team_name, const char *addr, const char *cli_type)
+{
+    if (callback_teamdctl_connect)
+    {
+        return callback_teamdctl_connect(tdc, team_name, addr, cli_type);
+    }
+    int (*realfunc)(struct teamdctl *, const char *, const char *, const char *) =
+        (int    (*)(struct teamdctl *, const char *, const char *, const char *))(dlsym (RTLD_NEXT, "teamdctl_connect"));
+    return realfunc(tdc, team_name, addr, cli_type);
+}
+
+static int cb_teamdctl_config_get_raw_direct_force_error(struct teamdctl *tdc, char **response)
+{
+    // Forced error
+    return 1;
+}
+
+static int cb_teamdctl_config_get_raw_direct_success(struct teamdctl *tdc, char **response)
+{
+    return 0;
+}
+
+int teamdctl_config_get_raw_direct(struct teamdctl *tdc, char **response)
+{
+    if (callback_teamdctl_config_get_raw_direct)
+    {
+        return callback_teamdctl_config_get_raw_direct(tdc, response);
+    }
+    int (*realfunc)(struct teamdctl *, char **) =
+        (int    (*)(struct teamdctl *, char **))(dlsym (RTLD_NEXT, "teamdctl_config_get_raw_direct"));
+    return realfunc(tdc, response);
+}
+
+static void cb_teamdctl_disconnect(struct teamdctl *tdc)
+{
+}
+
+void teamdctl_disconnect(struct teamdctl *tdc)
+{
+    if (callback_teamdctl_disconnect)
+    {
+        callback_teamdctl_disconnect(tdc);
+        return;
+    }
+    int (*realfunc)(struct teamdctl *) =
+        (int    (*)(struct teamdctl *))(dlsym (RTLD_NEXT, "teamdctl_disconnect"));
+    realfunc(tdc);
+}
+
+namespace teamportsync_test
+{
+    struct TeamPortSyncTest : public ::testing::Test
+    {
+        virtual void SetUp() override
+        {
+            callback_sleep = cb_sleep;
+            callback_team_init = NULL;
+            callback_team_change_handler = NULL;
+            callback_teamdctl_connect = NULL;
+            callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_force_error;
+            callback_teamdctl_disconnect = cb_teamdctl_disconnect;
+        }
+
+        virtual void TearDown() override
+        {
+            callback_sleep = NULL;
+            callback_team_init = NULL;
+            callback_team_change_handler = NULL;
+            callback_teamdctl_connect = NULL;
+            callback_teamdctl_config_get_raw_direct = NULL;
+            callback_teamdctl_disconnect = NULL;
+        }
+    };
+
+    TEST_F(TeamPortSyncTest, TestInvalidIfIndex)
+    {
+        try {
+            swss::TeamSync::TeamPortSync("testLag", 0, NULL);
+            FAIL();
+        } catch (std::runtime_error &exception) {
+            EXPECT_THAT(exception.what(), testing::HasSubstr("Unable to initialize team socket"));
+        }
+    }
+
+    TEST_F(TeamPortSyncTest, NoLagPresent)
+    {
+        try {
+            swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+            FAIL();
+        } catch (std::runtime_error &exception) {
+            EXPECT_THAT(exception.what(), testing::HasSubstr("Unable to initialize team socket"));
+        }
+    }
+
+    TEST_F(TeamPortSyncTest, TeamdctlNoConfig)
+    {
+        callback_team_init = cb_team_init;
+        callback_team_change_handler = cb_team_change_handler;
+        callback_teamdctl_connect = cb_teamdctl_connect;
+        try {
+            swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+            FAIL();
+        } catch (std::runtime_error &exception) {
+            EXPECT_THAT(exception.what(), testing::HasSubstr("Unable to get config from teamd"));
+        }
+    }
+
+    TEST_F(TeamPortSyncTest, AllSuccess)
+    {
+        callback_team_init = cb_team_init;
+        callback_team_change_handler = cb_team_change_handler;
+        callback_teamdctl_connect = cb_teamdctl_connect;
+        callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_success;
+        swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+    }
+}

--- a/tests/p4rt/l3.py
+++ b/tests/p4rt/l3.py
@@ -35,7 +35,7 @@ class P4RtRouterInterfaceWrapper(util.DBInterface):
             assert status == True
             is_loopback = False
             is_gVR = False
-            for f,v in fvs:
+            for f, v in fvs:
                 if f == "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID":
                     is_gVR = True
                 if f == "SAI_ROUTER_INTERFACE_ATTR_TYPE" and v == "SAI_ROUTER_INTERFACE_TYPE_LOOPBACK":
@@ -67,7 +67,8 @@ class P4RtRouterInterfaceWrapper(util.DBInterface):
 
     def generate_app_db_key(self, router_interface_id):
         d = {}
-        d[util.prepend_match_field("router_interface_id")] = router_interface_id
+        d[util.prepend_match_field("router_interface_id")
+          ] = router_interface_id
         key = json.dumps(d, separators=(",", ":"))
         return self.TBL_NAME + ":" + key
 
@@ -87,6 +88,7 @@ class P4RtRouterInterfaceWrapper(util.DBInterface):
         router_intf_key = self.generate_app_db_key(router_interface_id)
         self.set_app_db_entry(router_intf_key, attr_list)
         return router_interface_id, router_intf_key, attr_list
+
 
 class P4RtGreTunnelWrapper(util.DBInterface):
     """Interface to interact with APP DB and ASIC DB tables for P4RT GRE Tunnel object."""
@@ -130,7 +132,8 @@ class P4RtGreTunnelWrapper(util.DBInterface):
         encap_dst_ip = encap_dst_ip or self.DEFAULT_ENCAP_DST_IP
         action = action or self.DEFAULT_ACTION
         attr_list = [
-            (util.prepend_param_field(self.ROUTER_ROUTER_INTERFACE_ID_FIELD), router_interface_id),
+            (util.prepend_param_field(
+                self.ROUTER_ROUTER_INTERFACE_ID_FIELD), router_interface_id),
             (util.prepend_param_field(self.ENCAP_SRC_IP_FIELD), encap_src_ip),
             (util.prepend_param_field(self.ENCAP_DST_IP_FIELD), encap_dst_ip),
             (self.ACTION_FIELD, action),
@@ -159,11 +162,9 @@ class P4RtGreTunnelWrapper(util.DBInterface):
         return tunnel_oid
 
     def get_original_appl_db_entries_count(self):
-        return len(
-            self._original_entries[
-                "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
-            ]
-        )
+        key = "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
+        entries = self._original_entries.get(key, [])
+        return len(entries)
 
     def get_original_appl_state_db_entries_count(self):
         return len(
@@ -179,6 +180,7 @@ class P4RtGreTunnelWrapper(util.DBInterface):
                 "%s:%s" % (self.asic_db, self.ASIC_DB_TBL_NAME)
             ]
         )
+
 
 class P4RtNeighborWrapper(util.DBInterface):
     """Interface to interact with APP DB and ASIC DB tables for P4RT neighbor object."""
@@ -201,7 +203,8 @@ class P4RtNeighborWrapper(util.DBInterface):
 
     def generate_app_db_key(self, router_interface_id, neighbor_id):
         d = {}
-        d[util.prepend_match_field("router_interface_id")] = router_interface_id
+        d[util.prepend_match_field("router_interface_id")
+          ] = router_interface_id
         d[util.prepend_match_field("neighbor_id")] = neighbor_id
         key = json.dumps(d, separators=(",", ":"))
         return self.TBL_NAME + ":" + key
@@ -225,7 +228,8 @@ class P4RtNeighborWrapper(util.DBInterface):
             (util.prepend_param_field(self.DST_MAC_FIELD), dst_mac),
             (self.ACTION_FIELD, action),
         ]
-        neighbor_key = self.generate_app_db_key(router_interface_id, neighbor_id)
+        neighbor_key = self.generate_app_db_key(
+            router_interface_id, neighbor_id)
         self.set_app_db_entry(neighbor_key, attr_list)
         return neighbor_id, neighbor_key, attr_list
 
@@ -292,7 +296,8 @@ class P4RtNextHopWrapper(util.DBInterface):
         disable_dst_mac_rewrite=0,
         disable_vlan_rewrite=0
     ):
-        action = action or (self.DEFAULT_ACTION if tunnel_id == None else self.TUNNEL_ACTION)
+        action = action or (self.DEFAULT_ACTION if tunnel_id is None
+                            else self.TUNNEL_ACTION)
         router_interface_id = router_interface_id or self.DEFAULT_ROUTER_INTERFACE_ID
         if ipv4 is True:
             neighbor_id = neighbor_id or self.DEFAULT_IPV4_NEIGHBOR_ID
@@ -317,7 +322,8 @@ class P4RtNextHopWrapper(util.DBInterface):
                 self.DISABLE_VLAN_REWRITE_FIELD),
                 str(disable_vlan_rewrite)))
         if tunnel_id != None:
-            attr_list.append((util.prepend_param_field(self.TUNNEL_ID_FIELD), tunnel_id))
+            attr_list.append((util.prepend_param_field(
+                self.TUNNEL_ID_FIELD), tunnel_id))
         nexthop_key = self.generate_app_db_key(nexthop_id)
         self.set_app_db_entry(nexthop_key, attr_list)
         return nexthop_id, nexthop_key, attr_list
@@ -344,23 +350,19 @@ class P4RtNextHopWrapper(util.DBInterface):
     def get_newly_created_asic_db_key(self):
         asic_db_key = None
         nexthop_entries = util.get_keys(self.asic_db, self.ASIC_DB_TBL_NAME)
+        original_entries_key = "%s:%s" % (self.asic_db, self.ASIC_DB_TBL_NAME)
+        original_keys = self._original_entries.get(original_entries_key, [])
+
         for key in nexthop_entries:
-            if (
-                key
-                not in self._original_entries[
-                    "%s:%s" % (self.asic_db, self.ASIC_DB_TBL_NAME)
-                ]
-            ):
+            if key not in original_keys:
                 asic_db_key = key
                 break
         return asic_db_key
 
     def get_original_appl_db_entries_count(self):
-        return len(
-            self._original_entries[
-                "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
-            ]
-        )
+        key = "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
+        entries = self._original_entries.get(key, [])
+        return len(entries)
 
     def get_original_appl_state_db_entries_count(self):
         return len(
@@ -377,6 +379,7 @@ class P4RtNextHopWrapper(util.DBInterface):
             ]
         )
 
+
 class P4RtWcmpGroupWrapper(util.DBInterface):
     """Interface to interact with APP DB and ASIC DB tables for P4RT wcmp group object."""
 
@@ -385,15 +388,11 @@ class P4RtWcmpGroupWrapper(util.DBInterface):
     TBL_NAME = swsscommon.APP_P4RT_WCMP_GROUP_TABLE_NAME
     ASIC_DB_GROUP_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP"
     SAI_ATTR_GROUP_TYPE = "SAI_NEXT_HOP_GROUP_ATTR_TYPE"
-    SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP = (
-        "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP"
+    SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS = (
+        "SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS"
     )
-    ASIC_DB_GROUP_MEMBER_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER"
-    SAI_ATTR_GROUP_MEMBER_NEXTHOP_GROUP_ID = (
-        "SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID"
-    )
-    SAI_ATTR_GROUP_MEMBER_NEXTHOP_ID = "SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID"
-    SAI_ATTR_GROUP_MEMBER_WEIGHT = "SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT"
+    SAI_ATTR_NEXT_HOP_LIST = "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST"
+    SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST = "SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST"
 
     # attribute fields for wcmp group object
     NEXTHOP_ID_FIELD = "nexthop_id"
@@ -416,7 +415,8 @@ class P4RtWcmpGroupWrapper(util.DBInterface):
     # 'get_original_redis_entries' before fetching oid of newly created wcmp group.
     def get_newly_created_wcmp_group_oid(self):
         wcmp_group_oid = None
-        wcmp_group_entries = util.get_keys(self.asic_db, self.ASIC_DB_GROUP_TBL_NAME)
+        wcmp_group_entries = util.get_keys(
+            self.asic_db, self.ASIC_DB_GROUP_TBL_NAME)
         for key in wcmp_group_entries:
             if (
                 key
@@ -427,28 +427,6 @@ class P4RtWcmpGroupWrapper(util.DBInterface):
                 wcmp_group_oid = key
                 break
         return wcmp_group_oid
-
-    # Fetch key for the first newly created wcmp group member from created group
-    # members in ASIC db. This API should only be used when only one key is
-    # expected to be created after the original entries.
-    # Original wcmp group member entries in asic db must be fetched using
-    # 'get_original_redis_entries' before fetching asic db key of newly created
-    # wcmp group member.
-    def get_newly_created_wcmp_group_member_asic_db_key(self):
-        asic_db_wcmp_group_member_key = None
-        wcmp_group_member_entries = util.get_keys(
-            self.asic_db, self.ASIC_DB_GROUP_MEMBER_TBL_NAME
-        )
-        for key in wcmp_group_member_entries:
-            if (
-                key
-                not in self._original_entries[
-                    "{}:{}".format(self.asic_db, self.ASIC_DB_GROUP_MEMBER_TBL_NAME)
-                ]
-            ):
-                asic_db_wcmp_group_member_key = key
-                break
-        return asic_db_wcmp_group_member_key
 
     def generate_app_db_key(self, group_id):
         d = {}
@@ -483,11 +461,9 @@ class P4RtWcmpGroupWrapper(util.DBInterface):
         return wcmp_group_id, wcmp_group_key, attr_list
 
     def get_original_appl_db_entries_count(self):
-        return len(
-            self._original_entries[
-                "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
-            ]
-        )
+        key = "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
+        entries = self._original_entries.get(key, [])
+        return len(entries)
 
     def get_original_appl_state_db_entries_count(self):
         return len(
@@ -501,13 +477,6 @@ class P4RtWcmpGroupWrapper(util.DBInterface):
         return len(
             self._original_entries[
                 "%s:%s" % (self.asic_db, self.ASIC_DB_GROUP_TBL_NAME)
-            ]
-        )
-
-    def get_original_asic_db_member_entries_count(self):
-        return len(
-            self._original_entries[
-                "%s:%s" % (self.asic_db, self.ASIC_DB_GROUP_MEMBER_TBL_NAME)
             ]
         )
 
@@ -607,23 +576,19 @@ class P4RtRouteWrapper(util.DBInterface):
     def get_newly_created_asic_db_key(self):
         asic_db_key = None
         route_entries = util.get_keys(self.asic_db, self.ASIC_DB_TBL_NAME)
+        original_entries_key = "%s:%s" % (self.asic_db, self.ASIC_DB_TBL_NAME)
+        original_keys = self._original_entries.get(original_entries_key, [])
+
         for key in route_entries:
-            if (
-                key
-                not in self._original_entries[
-                    "%s:%s" % (self.asic_db, self.ASIC_DB_TBL_NAME)
-                ]
-            ):
+            if key not in original_keys:
                 asic_db_key = key
                 break
         return asic_db_key
 
     def get_original_appl_db_entries_count(self):
-        return len(
-            self._original_entries[
-                "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
-            ]
-        )
+        key = "%s:%s" % (self.appl_db, (self.APP_DB_TBL_NAME + ":" + self.TBL_NAME))
+        entries = self._original_entries.get(key, [])
+        return len(entries)
 
     def get_original_appl_state_db_entries_count(self):
         return len(

--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -2039,6 +2039,123 @@ class TestP4RTL3(object):
         )
         self._clean_vrf(dvs)
 
+    @pytest.mark.skip(reason="sairedis vs MY MAC support is not ready")
+    def test_RouterInterfaceMtuUpdate(self, dvs, testlog):
+        self._set_up(dvs)
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        adb = swsscommon.DBConnector(swsscommon.APPL_STATE_DB, dvs.redis_sock, 0)
+
+        db_list = (
+            (
+                self._p4rt_router_intf_obj.appl_db,
+                "%s:%s"
+                % (self._p4rt_router_intf_obj.APP_DB_TBL_NAME,
+                   self._p4rt_router_intf_obj.TBL_NAME),
+            ),
+            (self._p4rt_router_intf_obj.asic_db,
+             self._p4rt_router_intf_obj.ASIC_DB_TBL_NAME),
+        )
+        self._p4rt_router_intf_obj.get_original_redis_entries(db_list)
+
+        # Create router interface.
+        port = "Ethernet8"
+        (
+            router_interface_id,
+            router_intf_key,
+            attr_list,
+        ) = self._p4rt_router_intf_obj.create_router_interface(port_id=port)
+        util.verify_response(
+            self.response_consumer, router_intf_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+
+        rif_oid = (
+            self._p4rt_router_intf_obj.get_newly_created_router_interface_oid())
+        assert rif_oid is not None
+        (status, fvs) = util.get_key(
+            self._p4rt_router_intf_obj.asic_db,
+            self._p4rt_router_intf_obj.ASIC_DB_TBL_NAME,
+            rif_oid,
+        )
+        assert status == True
+        attribute_found = False
+        for fv in fvs:
+            if fv[0] == self._p4rt_router_intf_obj.SAI_ATTR_MTU:
+                assert fv[1] == self._p4rt_router_intf_obj.SAI_ATTR_DEFAULT_MTU
+                attribute_found = True
+                break
+        assert attribute_found == True
+
+        # Fetch original MTU.
+        tbl = swsscommon.Table(adb, "PORT_TABLE")
+        (status, fvs) = tbl.get(port)
+        assert status == True
+        orig_mtu = None
+        for fv in fvs:
+            if fv[0] == "mtu":
+                orig_mtu = fv[1]
+                break
+        assert orig_mtu is not None
+
+        # Update port MTU.
+        tbl = swsscommon.Table(cdb, "PORT")
+        mtu = "5678"
+        fvs = swsscommon.FieldValuePairs([("mtu", mtu)])
+        tbl.set(port, fvs)
+        time.sleep(1)
+
+        # Check application state database.
+        tbl = swsscommon.Table(adb, "PORT_TABLE")
+        (status, fvs) = tbl.get(port)
+        assert status == True
+        attribute_found = False
+        for fv in fvs:
+            if fv[0] == "mtu":
+                assert fv[1] == mtu
+                attribute_found = True
+                break
+        assert attribute_found == True
+
+        # Verify that MTU has been updated in P4RT router interface.
+        (status, fvs) = util.get_key(
+            self._p4rt_router_intf_obj.asic_db,
+            self._p4rt_router_intf_obj.ASIC_DB_TBL_NAME,
+            rif_oid,
+        )
+        assert status == True
+        attribute_found = False
+        for fv in fvs:
+            if fv[0] == self._p4rt_router_intf_obj.SAI_ATTR_MTU:
+                assert fv[1] == mtu
+                attribute_found = True
+                break
+        assert attribute_found == True
+
+        # Restore original MTU.
+        tbl = swsscommon.Table(cdb, "PORT")
+        fvs = swsscommon.FieldValuePairs([("mtu", orig_mtu)])
+        tbl.set(port, fvs)
+        time.sleep(1)
+
+        # Verify that MTU has been updated in P4RT router interface.
+        (status, fvs) = util.get_key(
+            self._p4rt_router_intf_obj.asic_db,
+            self._p4rt_router_intf_obj.ASIC_DB_TBL_NAME,
+            rif_oid,
+        )
+        assert status == True
+        attribute_found = False
+        for fv in fvs:
+            if fv[0] == self._p4rt_router_intf_obj.SAI_ATTR_MTU:
+                assert fv[1] == orig_mtu
+                attribute_found = True
+                break
+        assert attribute_found == True
+
+        # Remove router interface.
+        self._p4rt_router_intf_obj.remove_app_db_entry(router_intf_key)
+        util.verify_response(
+            self.response_consumer, router_intf_key, [], "SWSS_RC_SUCCESS"
+        )
 
     def test_NexthopAddWithRewrite(self, dvs, testlog):
         # Initialize L3 objects and database connectors.

--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -383,10 +383,6 @@ class TestP4RTL3(object):
                 self._p4rt_wcmp_group_obj.asic_db,
                 self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
             ),
-            (
-                self._p4rt_wcmp_group_obj.asic_db,
-                self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            ),
         )
         self._p4rt_wcmp_group_obj.get_original_redis_entries(db_list)
 
@@ -464,46 +460,21 @@ class TestP4RTL3(object):
         attr_list = [
             (
                 self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
-                self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP,
+                self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS,
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "1:" + nexthop_oid,
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
             )
         ]
         (status, fvs) = util.get_key(
             self._p4rt_wcmp_group_obj.asic_db,
             self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
             wcmp_group_oid,
-        )
-        assert status == True
-        util.verify_attr(fvs, attr_list)
-
-        # Query ASIC database for wcmp group member entries.
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count() + 1
-        )
-
-        # Query ASIC database for newly crated wcmp group member key.
-        asic_db_group_member_key = (
-            self._p4rt_wcmp_group_obj.get_newly_created_wcmp_group_member_asic_db_key()
-        )
-        assert asic_db_group_member_key is not None
-        attr_list = [
-            (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_GROUP_ID,
-                wcmp_group_oid,
-            ),
-            (self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_ID, nexthop_oid),
-            (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_WEIGHT,
-                str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
-            ),
-        ]
-        (status, fvs) = util.get_key(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            asic_db_group_member_key,
         )
         assert status == True
         util.verify_attr(fvs, attr_list)
@@ -753,24 +724,6 @@ class TestP4RTL3(object):
             self._p4rt_wcmp_group_obj.asic_db,
             self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
             wcmp_group_oid,
-        )
-        assert status == False
-
-        # Query ASIC database for wcmp group member entries.
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count()
-        )
-
-        # Verify that removed wcmp group member no longer exists in ASIC
-        # database.
-        (status, fvs) = util.get_key(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            asic_db_group_member_key,
         )
         assert status == False
 
@@ -1188,10 +1141,6 @@ class TestP4RTL3(object):
                 self._p4rt_wcmp_group_obj.asic_db,
                 self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
             ),
-            (
-                self._p4rt_wcmp_group_obj.asic_db,
-                self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            ),
         )
         self._p4rt_wcmp_group_obj.get_original_redis_entries(db_list)
         db_list = (
@@ -1283,33 +1232,17 @@ class TestP4RTL3(object):
             (
                 self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
                 (
-                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
                 ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "1:" + nexthop_oid,
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
             )
-        ]
-        util.verify_attr(fvs, asic_attr_list)
-
-        # Query ASIC database for newly created wcmp group member key.
-        asic_db_group_member_key = (
-            self._p4rt_wcmp_group_obj.get_newly_created_wcmp_group_member_asic_db_key()
-        )
-        assert asic_db_group_member_key is not None
-        (status, fvs) = util.get_key(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            asic_db_group_member_key,
-        )
-        assert status == True
-        asic_attr_list = [
-            (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_GROUP_ID,
-                wcmp_group_oid,
-            ),
-            (self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_ID, nexthop_oid),
-            (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_WEIGHT,
-                str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
-            ),
         ]
         util.verify_attr(fvs, asic_attr_list)
 
@@ -1318,35 +1251,56 @@ class TestP4RTL3(object):
 
         # Check ASIC DB to verify that associated member for watch_port is
         # pruned.
-        wcmp_group_member_entries = util.get_keys(
+        (status, fvs) = util.get_key(
             self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+            wcmp_group_oid,
         )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count()
-        )
+        assert status == True
+        asic_attr_list = [
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                (
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "0:null",
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "0:null",
+            )
+        ]
+        util.verify_attr(fvs, asic_attr_list)
 
         # Force oper-up for associated port.
         util.set_interface_status(dvs, if_name, "up")
 
         # Check pruned next hop member is restored in ASIC DB.
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count() + 1
-        )
-        asic_db_group_member_key = (
-            self._p4rt_wcmp_group_obj.get_newly_created_wcmp_group_member_asic_db_key()
-        )
-        assert asic_db_group_member_key is not None
         (status, fvs) = util.get_key(
             self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            asic_db_group_member_key,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+            wcmp_group_oid,
         )
         assert status == True
+        asic_attr_list = [
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                (
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "1:" + nexthop_oid,
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
+            )
+        ]
         util.verify_attr(fvs, asic_attr_list)
 
         # Delete WCMP group member.
@@ -1380,10 +1334,6 @@ class TestP4RTL3(object):
                 self._p4rt_wcmp_group_obj.asic_db,
                 self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
             ),
-            (
-                self._p4rt_wcmp_group_obj.asic_db,
-                self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            ),
         )
         self._p4rt_wcmp_group_obj.get_original_redis_entries(db_list)
         db_list = (
@@ -1475,42 +1425,17 @@ class TestP4RTL3(object):
             (
                 self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
                 (
-                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
                 ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "1:" + nexthop_oid,
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
             )
-        ]
-        util.verify_attr(fvs, asic_attr_list)
-
-        # Query ASIC database for wcmp group member entries.
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count() + 1
-        )
-
-        # Query ASIC database for newly created wcmp group member key.
-        asic_db_group_member_key = (
-            self._p4rt_wcmp_group_obj.get_newly_created_wcmp_group_member_asic_db_key()
-        )
-        assert asic_db_group_member_key is not None
-        (status, fvs) = util.get_key(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            asic_db_group_member_key,
-        )
-        assert status == True
-        asic_attr_list = [
-            (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_GROUP_ID,
-                wcmp_group_oid,
-            ),
-            (self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_ID, nexthop_oid),
-            (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_WEIGHT,
-                str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
-            ),
         ]
         util.verify_attr(fvs, asic_attr_list)
 
@@ -1526,13 +1451,31 @@ class TestP4RTL3(object):
         dvs.check_swss_ready()
 
         # Verify that the associated next hop is pruned in ASIC DB.
-        wcmp_group_member_entries = util.get_keys(
+        wcmp_group_oid = self._p4rt_wcmp_group_obj.get_newly_created_wcmp_group_oid()
+        assert wcmp_group_oid is not None
+        (status, fvs) = util.get_key(
             self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+            wcmp_group_oid,
         )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count()
-        )
+        assert status == True
+        asic_attr_list = [
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                (
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "0:null",
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "0:null",
+            )
+        ]
+        util.verify_attr(fvs, asic_attr_list)
 
         # Delete WCMP group member.
         self._p4rt_wcmp_group_obj.remove_app_db_entry(wcmp_group_key)
@@ -1564,10 +1507,6 @@ class TestP4RTL3(object):
             (
                 self._p4rt_wcmp_group_obj.asic_db,
                 self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
-            ),
-            (
-                self._p4rt_wcmp_group_obj.asic_db,
-                self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
             ),
         )
         self._p4rt_wcmp_group_obj.get_original_redis_entries(db_list)
@@ -1660,52 +1599,45 @@ class TestP4RTL3(object):
             (
                 self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
                 (
-                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
                 ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "0:null",
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "0:null",
             )
         ]
         util.verify_attr(fvs, asic_attr_list)
-
-        # Query ASIC database for wcmp group member entries (expect no entry).
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count()
-        )
 
         # Bring up the port.
         util.set_interface_status(dvs, if_name, "up")
 
         # Verify that next hop member is now created in SAI.
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count() + 1
-        )
-        asic_db_group_member_key = (
-            self._p4rt_wcmp_group_obj.get_newly_created_wcmp_group_member_asic_db_key()
-        )
-        assert asic_db_group_member_key is not None
         (status, fvs) = util.get_key(
             self._p4rt_wcmp_group_obj.asic_db,
-            (self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME),
-            asic_db_group_member_key,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+            wcmp_group_oid,
         )
         assert status == True
         asic_attr_list = [
             (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_GROUP_ID,
-                wcmp_group_oid,
+                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                (
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                ),
             ),
-            (self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_NEXTHOP_ID, nexthop_oid),
             (
-                self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_MEMBER_WEIGHT,
-                str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "1:" + nexthop_oid,
             ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
+            )
         ]
         util.verify_attr(fvs, asic_attr_list)
 
@@ -1740,10 +1672,6 @@ class TestP4RTL3(object):
                 self._p4rt_wcmp_group_obj.asic_db,
                 self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
             ),
-            (
-                self._p4rt_wcmp_group_obj.asic_db,
-                self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-            ),
         )
         self._p4rt_wcmp_group_obj.get_original_redis_entries(db_list)
         db_list = (
@@ -1835,30 +1763,19 @@ class TestP4RTL3(object):
             (
                 self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
                 (
-                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP
+                    self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
                 ),
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                "0:null",
+            ),
+            (
+                self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                "0:null",
             )
         ]
         util.verify_attr(fvs, asic_attr_list)
-
-        # Query ASIC database for wcmp group member entries.
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count() + 1
-        )
-
-        # Query ASIC database for wcmp group member entries (expect no entry).
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert (
-            len(wcmp_group_member_entries)
-            == self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count()
-        )
 
         # Attempt to delete the next hop. Expect failure as the pruned WCMP
         # group member is still referencing it.
@@ -1874,13 +1791,6 @@ class TestP4RTL3(object):
         )
         assert len(wcmp_group_entries) == (
             self._p4rt_wcmp_group_obj.get_original_asic_db_group_entries_count()
-        )
-        wcmp_group_member_entries = util.get_keys(
-            self._p4rt_wcmp_group_obj.asic_db,
-            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_MEMBER_TBL_NAME,
-        )
-        assert len(wcmp_group_member_entries) == (
-            self._p4rt_wcmp_group_obj.get_original_asic_db_member_entries_count()
         )
 
         # Delete next hop.
@@ -2222,3 +2132,16 @@ class TestP4RTL3(object):
                      (self._p4rt_nexthop_obj.SAI_ATTR_DISABLE_VLAN_REWRITE,
                       "true")]
         util.verify_attr(fvs, attr_list)
+
+        # Cleanup
+        self._p4rt_nexthop_obj.remove_app_db_entry(nexthop_key)
+        util.verify_response(
+            self.response_consumer, nexthop_key, [], "SWSS_RC_SUCCESS")
+        self._p4rt_neighbor_obj.remove_app_db_entry(neighbor_key)
+        util.verify_response(
+            self.response_consumer, neighbor_key, [], "SWSS_RC_SUCCESS")
+        self._p4rt_router_intf_obj.remove_app_db_entry(router_intf_key)
+        util.verify_response(
+            self.response_consumer, router_intf_key, [], "SWSS_RC_SUCCESS")
+
+        self._clean_vrf(dvs)

--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -5,7 +5,7 @@ import json
 import util
 import l3
 import test_vrf
-
+import time
 
 class TestP4RTL3(object):
     def _set_up(self, dvs):
@@ -1442,7 +1442,7 @@ class TestP4RTL3(object):
         # Bring down the port.
         util.set_interface_status(dvs, if_name)
 
-        # Execute the warm reboot.
+        # Execute the warm reboot
         dvs.warm_restart_swss("true")
         dvs.stop_swss()
         dvs.start_swss()

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -734,6 +734,26 @@ class TestP4RTAcl(object):
         meter_pbs = "200"
         table_name_with_rule_key2 = table_name + ":" + rule_json_key2
 
+    # First attempt failed since no UserDefinedTrap is created for the CPU queue    
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/cpu_queue", "30"), # No UserDefinedTrap created for the queue.
+            (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
+            (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
+            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
+            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
+        ]
+
+        self._p4rt_acl_rule_obj.set_app_db_entry(
+            table_name_with_rule_key2, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key2,
+            attr_list,
+            "SWSS_RC_INVALID_PARAM",
+            "[OrchAgent] Invalid CPU queue number '30' for 'ACL_PUNT_TABLE_RULE_TEST'. Queue number 30 does not have UserDefinedTrap configured",
+        )
+
         attr_list = [
             (self._p4rt_acl_rule_obj.ACTION, action),
             ("param/cpu_queue", "5"),

--- a/tests/test_buffer_traditional.py
+++ b/tests/test_buffer_traditional.py
@@ -446,3 +446,83 @@ class TestBuffer(object):
             else:
                 self.config_db.delete_entry("PORT_QOS_MAP", self.INTF)
 
+    def test_update_buffer_pg_for_cable_len_change(self, dvs: DockerVirtualSwitch, setup_teardown_test):
+        """
+        Test to verify that buffermgrd correctly updated the buffer_pg entry of a given port when cable length is
+        updated.
+        """
+
+        orig_port_qos_map = None
+        orig_cable_len = None
+        orig_fvs_port = None
+
+        # Test parameters
+        test_cable_len = "300m"
+        test_speed = "100000"
+        test_port_pfc_enable = "3,4"
+
+        try:
+            ##################################
+            ## Save original configurations ##
+            ##################################
+
+            # Save original cable length
+            fvs_cable_len = self.config_db.get_entry("CABLE_LENGTH", "AZURE")
+            orig_cable_len = fvs_cable_len.get(self.INTF) if fvs_cable_len else None
+
+            # Save original port speed and admin status
+            orig_fvs_port = self.config_db.get_entry("PORT", self.INTF)
+
+            # Save original port qos map
+            fvs_qos_map = self.config_db.get_entry("PORT_QOS_MAP", self.INTF)
+            orig_port_qos_map = fvs_qos_map if fvs_qos_map else None
+
+            ######################################
+            ## Send configurations to CONFIG_DB ##
+            ######################################
+
+            # Configure PFC enable
+            self.set_port_qos_table(self.INTF, test_port_pfc_enable)
+
+            # Configure cable length
+            self.change_cable_len(test_cable_len)
+
+            # Wait for buffermgrd to process the changes
+            time.sleep(2)
+
+            ##################
+            ## Verification ##
+            ##################
+
+            # Verify BUFFER_PG table entry in CONFIG_DB without port qos map entry
+            pg_field_key = "{}|{}".format(self.INTF, test_port_pfc_enable.replace(',', '-'))
+            fvs_buffer_pg = self.config_db.get_entry("BUFFER_PG", pg_field_key)
+
+            # Check if fvs_buffer_pg profile is not equal to expected dynamic profile
+            expected_profile = "pg_lossless_{}_{}_profile".format(test_speed, test_cable_len)
+            if fvs_buffer_pg.get("profile") != expected_profile:
+                assert False, "BUFFER_PG profile {} is not {}".format(fvs_buffer_pg.get("profile"), expected_profile)
+
+        finally:
+            ###############################
+            ## Revert to original values ##
+            ###############################
+
+            # Revert cable length
+            if orig_cable_len:
+                self.change_cable_len(orig_cable_len)
+            else:
+                self.config_db.delete_entry("CABLE_LENGTH", "AZURE")
+
+            # Revert to original PORT configuration
+            if orig_fvs_port:
+                self.config_db.update_entry("PORT", self.INTF, orig_fvs_port)
+            else:
+                self.config_db.delete_entry("PORT", self.INTF)
+
+            # Revert port qos map
+            if orig_port_qos_map:
+                self.config_db.update_entry("PORT_QOS_MAP", self.INTF, orig_port_qos_map)
+            else:
+                self.config_db.delete_entry("PORT_QOS_MAP", self.INTF)
+

--- a/tests/test_inband_intf_mgmt_vrf.py
+++ b/tests/test_inband_intf_mgmt_vrf.py
@@ -14,7 +14,7 @@ class TestInbandInterface(object):
 
     def add_mgmt_vrf(self, dvs):
         initial_entries = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")) 
-        dvs.runcmd("ip link add mgmt type vrf table 5000")
+        dvs.runcmd("ip link add mgmt type vrf table 6000")
         dvs.runcmd("ifconfig mgmt up")
         time.sleep(2)
 

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -35,6 +35,7 @@ ASIC_VIRTUAL_ROUTER_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER"
 ASIC_PORT_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_PORT"
 ASIC_LAG_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_LAG"
 ASIC_TUNNEL_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL"
+ASIC_SWITCH_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH"
 
 ADMIN_STATUS = "admin_status"
 VRF_NAME = "vrf_name"
@@ -84,6 +85,7 @@ class TestSubPortIntf(object):
         dvs.setup_db()
 
         self.default_vrf_oid = self.get_default_vrf_oid()
+        self.initial_vrf_count = len(self.get_oids(ASIC_VIRTUAL_ROUTER_TABLE))
 
         phy_port = self.SUB_PORT_INTERFACE_UNDER_TEST.split(VLAN_SUB_INTERFACE_SEPARATOR)[0]
 
@@ -389,8 +391,21 @@ class TestSubPortIntf(object):
         return oid[0]
 
     def get_default_vrf_oid(self):
+        # Query the switch object for the default virtual router ID instead of
+        # assuming there is exactly one VRF in ASIC_DB.  Other features (VRFs,
+        # VNETs, loopback-action, …) may legitimately create additional virtual
+        # routers before these tests run, so a count-based assertion is fragile.
+        tbl = swsscommon.Table(self.asic_db.db_connection, ASIC_SWITCH_TABLE)
+        switch_keys = tbl.getKeys()
+        assert len(switch_keys) >= 1, "No switch entry in ASIC_DB"
+        (status, fvs) = tbl.get(switch_keys[0])
+        assert status, "Failed to read switch entry from ASIC_DB"
+        for fv in fvs:
+            if fv[0] == "SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID":
+                return fv[1]
+        # Fallback: if the attribute is absent, use legacy behaviour
         oids = self.get_oids(ASIC_VIRTUAL_ROUTER_TABLE)
-        assert len(oids) == 1, "Wrong # of default vrfs: %d, expected #: 1." % (len(oids))
+        assert len(oids) >= 1, "No virtual routers found in ASIC_DB"
         return oids[0]
 
     def get_ip_prefix_nhg_oid(self, ip_prefix, vrf_oid=None, prefix_present=True):
@@ -1004,7 +1019,7 @@ class TestSubPortIntf(object):
         self.set_parent_port_admin_status(dvs, parent_port, "up")
         if vrf_name:
             self.create_vrf(vrf_name)
-            self.asic_db.wait_for_n_keys(ASIC_VIRTUAL_ROUTER_TABLE, 2)
+            self.asic_db.wait_for_n_keys(ASIC_VIRTUAL_ROUTER_TABLE, self.initial_vrf_count + 1)
         self.create_sub_port_intf_profile(sub_port_intf_name, vrf_name)
 
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
@@ -1056,7 +1071,7 @@ class TestSubPortIntf(object):
         # Remove vrf if created
         if vrf_name:
             self.remove_vrf(vrf_name)
-            self.asic_db.wait_for_n_keys(ASIC_VIRTUAL_ROUTER_TABLE, 1)
+            self.asic_db.wait_for_n_keys(ASIC_VIRTUAL_ROUTER_TABLE, self.initial_vrf_count)
             if vrf_name.startswith(VNET_PREFIX):
                 self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
                 self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
@@ -1238,7 +1253,7 @@ class TestSubPortIntf(object):
         # Remove vrf if created
         if vrf_name:
             self.remove_vrf(vrf_name)
-            self.asic_db.wait_for_n_keys(ASIC_VIRTUAL_ROUTER_TABLE, 1)
+            self.asic_db.wait_for_n_keys(ASIC_VIRTUAL_ROUTER_TABLE, self.initial_vrf_count)
             if vrf_name.startswith(VNET_PREFIX):
                 self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
                 self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -254,7 +254,7 @@ class TestVrf(object):
 
         initial_entries_cnt = self.how_many_entries_exist(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")
 
-        maximum_vrf_cnt = 999
+        maximum_vrf_cnt = 4096
 
         def create_entry(self, tbl, key, pairs):
             fvs = swsscommon.FieldValuePairs(pairs)


### PR DESCRIPTION
On nbrmgr restart, pre-existing entries in NEIGH_RESOLVE_TABLE were not being processed because ConsumerStateTable only delivers entries written after subscription. Added reconciliation logic that scans the table at startup and resolves any pending neighbor entries.

**Changes:**
- `cfgmgr/nbrmgr.cpp/h`: Added `reconcileNeighResolveTable()` called from constructor
- `tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp`: Unit tests for empty, IPv4, and IPv6 reconciliation
- `tests/mock_tests/Makefile.am`: Added `tests_nbrmgrd` test binary